### PR TITLE
Convert acquire-logger from a static library to an object library.

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -11,7 +11,6 @@ target_include_directories(${tgt} PRIVATE
         ${PROJECT_SOURCE_DIR}/src/logger
 )
 target_link_libraries(${tgt} PRIVATE
-        acquire-logger
         acquire-zarr
         nlohmann_json::nlohmann_json
         miniocpp::miniocpp

--- a/src/logger/CMakeLists.txt
+++ b/src/logger/CMakeLists.txt
@@ -1,19 +1,14 @@
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-add_library(acquire-logger
+add_library(acquire-logger-obj OBJECT
         logger.hh
         logger.cpp
 )
 
-target_include_directories(acquire-logger
-        INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-)
-
-set_target_properties(acquire-logger PROPERTIES
+set_target_properties(acquire-logger-obj PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
 )
 
-install(TARGETS acquire-logger
-        LIBRARY DESTINATION lib
+target_include_directories(acquire-logger-obj
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )

--- a/src/streaming/CMakeLists.txt
+++ b/src/streaming/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(${tgt}
         zarrv3.array.writer.cpp
         vectorized.file.writer.hh
         vectorized.file.writer.cpp
+        $<TARGET_OBJECTS:acquire-logger-obj>
 )
 
 target_include_directories(${tgt}
@@ -42,7 +43,6 @@ target_include_directories(${tgt}
 )
 
 target_link_libraries(${tgt} PRIVATE
-        acquire-logger
         blosc_static
         miniocpp::miniocpp
 )

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -23,7 +23,6 @@ foreach (name ${tests})
             ${PROJECT_SOURCE_DIR}/src/logger
     )
     target_link_libraries(${tgt} PRIVATE
-            acquire-logger
             acquire-zarr
             nlohmann_json::nlohmann_json
             miniocpp::miniocpp

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -41,7 +41,6 @@ foreach (name ${tests})
             ${PROJECT_SOURCE_DIR}/src/streaming
     )
     target_link_libraries(${tgt} PRIVATE
-            acquire-logger
             acquire-zarr
             miniocpp::miniocpp
     )


### PR DESCRIPTION
Closes #28.