### PR TITLE
Compress buffers immediately before writing out

### DIFF
--- a/src/streaming/array.writer.cpp
+++ b/src/streaming/array.writer.cpp
@@ -212,8 +212,7 @@ zarr::ArrayWriter::make_metadata_sink_()
 
     if (is_s3_array_()) {
         SinkCreator creator(thread_pool_, s3_connection_pool_);
-        metadata_sink_ =
-          creator.make_sink(*config_.bucket_name, metadata_path);
+        metadata_sink_ = creator.make_sink(*config_.bucket_name, metadata_path);
     } else {
         metadata_sink_ = zarr::SinkCreator::make_sink(metadata_path);
     }
@@ -334,62 +333,6 @@ zarr::ArrayWriter::should_flush_() const
 
     CHECK(frames_before_flush > 0);
     return frames_written_ % frames_before_flush == 0;
-}
-
-void
-zarr::ArrayWriter::compress_buffers_()
-{
-    if (!config_.compression_params.has_value()) {
-        return;
-    }
-
-    LOG_DEBUG("Compressing");
-
-    BloscCompressionParams params = config_.compression_params.value();
-    const auto bytes_per_px = bytes_of_type(config_.dtype);
-
-    std::scoped_lock lock(buffers_mutex_);
-    std::latch latch(chunk_buffers_.size());
-    for (auto& chunk : chunk_buffers_) {
-        EXPECT(thread_pool_->push_job(
-                 [&params, buf = &chunk, bytes_per_px, &latch](
-                   std::string& err) -> bool {
-                     bool success = false;
-                     const size_t bytes_of_chunk = buf->size();
-
-                     try {
-                         const auto tmp_size =
-                           bytes_of_chunk + BLOSC_MAX_OVERHEAD;
-                         ByteVector tmp(tmp_size);
-                         const auto nb =
-                           blosc_compress_ctx(params.clevel,
-                                              params.shuffle,
-                                              bytes_per_px,
-                                              bytes_of_chunk,
-                                              buf->data(),
-                                              tmp.data(),
-                                              tmp_size,
-                                              params.codec_id.c_str(),
-                                              0 /* blocksize - 0:automatic */,
-                                              1);
-
-                         tmp.resize(nb);
-                         buf->swap(tmp);
-
-                         success = true;
-                     } catch (const std::exception& exc) {
-                         err = "Failed to compress chunk: " +
-                               std::string(exc.what());
-                     }
-                     latch.count_down();
-
-                     return success;
-                 }),
-               "Failed to push to job queue");
-    }
-
-    // wait for all threads to finish
-    latch.wait();
 }
 
 void

--- a/src/streaming/array.writer.hh
+++ b/src/streaming/array.writer.hh
@@ -96,7 +96,6 @@ class ArrayWriter
 
     [[nodiscard]] virtual bool compress_and_flush_data_() = 0;
     [[nodiscard]] bool compress_buffer_(uint32_t index);
-    [[nodiscard]] virtual bool flush_impl_() = 0;
     void rollover_();
 
     [[nodiscard]] virtual bool write_array_metadata_() = 0;

--- a/src/streaming/array.writer.hh
+++ b/src/streaming/array.writer.hh
@@ -93,6 +93,9 @@ class ArrayWriter
     void compress_buffers_();
 
     void flush_();
+
+    [[nodiscard]] virtual bool compress_and_flush_data_() = 0;
+    [[nodiscard]] bool compress_buffer_(uint32_t index);
     [[nodiscard]] virtual bool flush_impl_() = 0;
     void rollover_();
 

--- a/src/streaming/array.writer.hh
+++ b/src/streaming/array.writer.hh
@@ -90,7 +90,6 @@ class ArrayWriter
     virtual bool should_rollover_() const = 0;
 
     size_t write_frame_to_chunks_(std::span<const std::byte> data);
-    void compress_buffers_();
 
     void flush_();
 

--- a/src/streaming/zarrv2.array.writer.cpp
+++ b/src/streaming/zarrv2.array.writer.cpp
@@ -86,42 +86,44 @@ zarr::ZarrV2ArrayWriter::compress_and_flush_data_()
 
     std::atomic<char> all_successful = 1;
     std::latch latch(n_chunks);
-    for (auto i = 0; i < n_chunks; ++i) {
-        EXPECT(
-          thread_pool_->push_job(
-            std::move([this, i, &latch, &all_successful](std::string& err) {
-                bool success = true;
+    {
+        std::scoped_lock lock(buffers_mutex_);
+        for (auto i = 0; i < n_chunks; ++i) {
+            EXPECT(
+              thread_pool_->push_job(
+                std::move([this, i, &latch, &all_successful](std::string& err) {
+                    bool success = true;
 
-                try {
-                    if (all_successful) {
-                        if (!compress_buffer_(i)) { // no-op if no compression
-                            err = "Failed to compress buffer";
-                            latch.count_down();
-                            return false;
+                    try {
+                        if (all_successful) {
+                            EXPECT(
+                              compress_buffer_(i), // no-op if no compression
+                              "Failed to compress buffer");
+
+                            auto& chunk = chunk_buffers_[i];
+                            auto& sink = data_sinks_[i];
+
+                            if (!sink->write(
+                                  0,
+                                  { reinterpret_cast<std::byte*>(chunk.data()),
+                                    chunk.size() })) {
+                                err = "Failed to write chunk";
+                                success = false;
+                            }
                         }
-
-                        auto& chunk = chunk_buffers_.at(i);
-                        auto& sink = data_sinks_.at(i);
-
-                        if (!sink->write(
-                              0,
-                              { reinterpret_cast<std::byte*>(chunk.data()),
-                                chunk.size() })) {
-                            err = "Failed to write chunk";
-                            success = false;
-                        }
+                    } catch (const std::exception& exc) {
+                        err =
+                          "Failed to flush data: " + std::string(exc.what());
+                        success = false;
                     }
-                } catch (const std::exception& exc) {
-                    err = "Failed to flush data: " + std::string(exc.what());
-                    success = false;
-                }
 
-                latch.count_down();
+                    latch.count_down();
 
-                all_successful.fetch_and(static_cast<char>(success));
-                return success;
-            })),
-          "Failed to push job to thread pool");
+                    all_successful.fetch_and(static_cast<char>(success));
+                    return success;
+                })),
+              "Failed to push job to thread pool");
+        }
     }
 
     latch.wait();

--- a/src/streaming/zarrv2.array.writer.hh
+++ b/src/streaming/zarrv2.array.writer.hh
@@ -15,6 +15,7 @@ class ZarrV2ArrayWriter final : public ArrayWriter
 
   private:
     ZarrVersion version_() const override { return ZarrVersion_2; };
+    bool compress_and_flush_data_() override;
     bool flush_impl_() override;
     bool write_array_metadata_() override;
     bool should_rollover_() const override;

--- a/src/streaming/zarrv2.array.writer.hh
+++ b/src/streaming/zarrv2.array.writer.hh
@@ -16,7 +16,6 @@ class ZarrV2ArrayWriter final : public ArrayWriter
   private:
     ZarrVersion version_() const override { return ZarrVersion_2; };
     bool compress_and_flush_data_() override;
-    bool flush_impl_() override;
     bool write_array_metadata_() override;
     bool should_rollover_() const override;
 };

--- a/src/streaming/zarrv3.array.writer.cpp
+++ b/src/streaming/zarrv3.array.writer.cpp
@@ -212,12 +212,6 @@ zarr::ZarrV3ArrayWriter::compress_and_flush_data_()
 }
 
 bool
-zarr::ZarrV3ArrayWriter::flush_impl_()
-{
-    return true;
-}
-
-bool
 zarr::ZarrV3ArrayWriter::write_array_metadata_()
 {
     if (!make_metadata_sink_()) {

--- a/src/streaming/zarrv3.array.writer.cpp
+++ b/src/streaming/zarrv3.array.writer.cpp
@@ -90,7 +90,7 @@ zarr::ZarrV3ArrayWriter::ZarrV3ArrayWriter(
 }
 
 bool
-zarr::ZarrV3ArrayWriter::flush_impl_()
+zarr::ZarrV3ArrayWriter::compress_and_flush_data_()
 {
     // create shard files if they don't exist
     if (data_sinks_.empty() && !make_data_sinks_()) {
@@ -100,7 +100,7 @@ zarr::ZarrV3ArrayWriter::flush_impl_()
     const auto n_shards = config_.dimensions->number_of_shards();
     CHECK(data_sinks_.size() == n_shards);
 
-    // get shard indices for each chunk
+    // construct shard indices for each chunk
     std::vector<std::vector<size_t>> chunk_in_shards(n_shards);
     const auto chunks_in_memory =
       config_.dimensions->number_of_chunks_in_memory();
@@ -110,6 +110,8 @@ zarr::ZarrV3ArrayWriter::flush_impl_()
           config_.dimensions->shard_index_for_chunk(i + chunk_group_offset);
         chunk_in_shards[index].push_back(i);
     }
+
+    std::atomic<char> all_successful = 1;
 
     // write out chunks to shards
     auto write_table = is_finalizing_ || should_rollover_();
@@ -122,54 +124,69 @@ zarr::ZarrV3ArrayWriter::flush_impl_()
         EXPECT(thread_pool_->push_job(std::move([&sink = data_sinks_.at(i),
                                                  &chunks,
                                                  &chunk_table,
-                                                 file_offset,
-                                                 write_table,
+                                                 &all_successful,
                                                  &latch,
+                                                 write_table,
+                                                 file_offset,
                                                  chunk_group_offset,
                                                  this](std::string& err) {
-            bool success = false;
+            bool success = true;
 
             try {
                 for (const auto& chunk_idx : chunks) {
-                    auto& chunk = chunk_buffers_.at(chunk_idx);
-                    std::span data(chunk);
-                    success = sink->write(*file_offset, data);
-                    if (!success) {
+                    if (!all_successful) {
+                        break;
+                    }
+
+                    // no-op if no compression
+                    if (!compress_buffer_(chunk_idx)) {
+                        err = "Failed to compress buffer";
+                        success = false;
+                        break;
+                    }
+
+                    auto& chunk = chunk_buffers_[chunk_idx];
+                    std::span chunk_data(chunk);
+                    if (!sink->write(*file_offset, chunk_data)) {
+                        err = "Failed to write chunk";
+                        success = false;
                         break;
                     }
 
                     const auto internal_idx =
                       config_.dimensions->shard_internal_index(
                         chunk_idx + chunk_group_offset);
-                    chunk_table.at(2 * internal_idx) = *file_offset;
-                    chunk_table.at(2 * internal_idx + 1) = chunk.size();
+                    chunk_table[2 * internal_idx] = *file_offset;
+                    chunk_table[2 * internal_idx + 1] = chunk.size();
 
                     *file_offset += chunk.size();
                 }
 
                 if (success && write_table) {
-                    const auto* table =
+                    const auto* table_ptr =
                       reinterpret_cast<std::byte*>(chunk_table.data());
-                    std::span data{ table,
-                                    chunk_table.size() * sizeof(uint64_t) };
-                    success = sink->write(*file_offset, data);
-                    EXPECT(success, "Failed to write table");
-
-                    *file_offset += data.size();
+                    const auto table_size =
+                      chunk_table.size() * sizeof(uint64_t);
+                    EXPECT(sink->write(*file_offset, { table_ptr, table_size }),
+                           "Failed to write table");
 
                     // compute crc32 checksum of the table
-                    const auto* utable =
-                      reinterpret_cast<const uint8_t*>(table);
-                    uint32_t crc = crc32c::Crc32c(utable, data.size());
-                    std::span crc_data{ reinterpret_cast<std::byte*>(&crc),
-                                        sizeof(crc) };
-                    success = sink->write(*file_offset, crc_data);
+                    uint32_t checksum = crc32c::Crc32c(
+                      reinterpret_cast<const uint8_t*>(table_ptr), table_size);
+                    EXPECT(
+                      sink->write(*file_offset + table_size,
+                                  { reinterpret_cast<std::byte*>(&checksum),
+                                    sizeof(checksum) }),
+                      "Failed to write checksum");
                 }
             } catch (const std::exception& exc) {
-                err = "Failed to write chunk: " + std::string(exc.what());
+                err = "Failed to flush data: " + std::string(exc.what());
+                success = false;
             }
 
             latch.count_down();
+
+            all_successful.fetch_and(static_cast<char>(success));
             return success;
         })),
                "Failed to push job to thread pool");
@@ -191,6 +208,12 @@ zarr::ZarrV3ArrayWriter::flush_impl_()
         ++flushed_count_;
     }
 
+    return static_cast<bool>(all_successful);
+}
+
+bool
+zarr::ZarrV3ArrayWriter::flush_impl_()
+{
     return true;
 }
 

--- a/src/streaming/zarrv3.array.writer.hh
+++ b/src/streaming/zarrv3.array.writer.hh
@@ -20,7 +20,6 @@ struct ZarrV3ArrayWriter : public ArrayWriter
 
     ZarrVersion version_() const override { return ZarrVersion_3; }
     bool compress_and_flush_data_() override;
-    bool flush_impl_() override;
     bool write_array_metadata_() override;
     bool should_rollover_() const override;
 };

--- a/src/streaming/zarrv3.array.writer.hh
+++ b/src/streaming/zarrv3.array.writer.hh
@@ -19,6 +19,7 @@ struct ZarrV3ArrayWriter : public ArrayWriter
     uint32_t flushed_count_;
 
     ZarrVersion version_() const override { return ZarrVersion_3; }
+    bool compress_and_flush_data_() override;
     bool flush_impl_() override;
     bool write_array_metadata_() override;
     bool should_rollover_() const override;

--- a/tests/unit-tests/array-writer-write-frame-to-chunks.cpp
+++ b/tests/unit-tests/array-writer-write-frame-to-chunks.cpp
@@ -15,6 +15,7 @@ class TestWriter : public zarr::ArrayWriter
   private:
     ZarrVersion version_() const override { return ZarrVersionCount; }
     bool should_rollover_() const override { return false; }
+    bool compress_and_flush_data_() override { return true; }
     bool flush_impl_() override { return true; }
     bool write_array_metadata_() override { return true; }
 };

--- a/tests/unit-tests/array-writer-write-frame-to-chunks.cpp
+++ b/tests/unit-tests/array-writer-write-frame-to-chunks.cpp
@@ -16,7 +16,6 @@ class TestWriter : public zarr::ArrayWriter
     ZarrVersion version_() const override { return ZarrVersionCount; }
     bool should_rollover_() const override { return false; }
     bool compress_and_flush_data_() override { return true; }
-    bool flush_impl_() override { return true; }
     bool write_array_metadata_() override { return true; }
 };
 } // namespace


### PR DESCRIPTION
Previous workflow was to use n threads to compress n buffers, then once this was done, use n threads again to write n buffers out to disk (or to S3). New workflow is to use compress and write each buffer sequentially in the same thread worker, so that, in principle, a single chunk can be compressed and written out before another chunk begins compressing. This should reduce thread synchronization overhead.