### PR TITLE
Remove ArrayWriter::version_()

### DIFF
--- a/src/streaming/array.writer.cpp
+++ b/src/streaming/array.writer.cpp
@@ -148,25 +148,8 @@ zarr::ArrayWriter::is_s3_array_() const
 bool
 zarr::ArrayWriter::make_data_sinks_()
 {
-    std::string data_root;
-    std::function<size_t(const ZarrDimension&)> parts_along_dimension;
-    switch (version_()) {
-        case ZarrVersion_2:
-            parts_along_dimension = chunks_along_dimension;
-            data_root = config_.store_path + "/" +
-                        std::to_string(config_.level_of_detail) + "/" +
-                        std::to_string(append_chunk_index_);
-            break;
-        case ZarrVersion_3:
-            parts_along_dimension = shards_along_dimension;
-            data_root = config_.store_path + "/" +
-                        std::to_string(config_.level_of_detail) + "/c/" +
-                        std::to_string(append_chunk_index_);
-            break;
-        default:
-            LOG_ERROR("Unsupported Zarr version");
-            return false;
-    }
+    const auto data_root = data_root_();
+    const auto parts_along_dimension = parts_along_dimension_();
 
     SinkCreator creator(thread_pool_, s3_connection_pool_);
 
@@ -200,22 +183,7 @@ zarr::ArrayWriter::make_metadata_sink_()
         return true;
     }
 
-    std::string metadata_path;
-    switch (version_()) {
-        case ZarrVersion_2:
-            metadata_path = config_.store_path + "/" +
-                            std::to_string(config_.level_of_detail) +
-                            "/.zarray";
-            break;
-        case ZarrVersion_3:
-            metadata_path = config_.store_path + "/" +
-                            std::to_string(config_.level_of_detail) +
-                            "/zarr.json";
-            break;
-        default:
-            LOG_ERROR("Unsupported Zarr version");
-            return false;
-    }
+    const auto metadata_path = metadata_path_();
 
     if (is_s3_array_()) {
         SinkCreator creator(thread_pool_, s3_connection_pool_);

--- a/src/streaming/array.writer.hh
+++ b/src/streaming/array.writer.hh
@@ -78,9 +78,10 @@ class ArrayWriter
 
     std::shared_ptr<S3ConnectionPool> s3_connection_pool_;
 
-    virtual ZarrVersion version_() const = 0;
-
     bool is_s3_array_() const;
+    virtual std::string data_root_() const = 0;
+    virtual std::string metadata_path_() const = 0;
+    virtual const DimensionPartsFun parts_along_dimension_() const = 0;
 
     [[nodiscard]] bool make_data_sinks_();
     [[nodiscard]] bool make_metadata_sink_();

--- a/src/streaming/sink.creator.cpp
+++ b/src/streaming/sink.creator.cpp
@@ -64,7 +64,7 @@ bool
 zarr::SinkCreator::make_data_sinks(
   std::string_view base_path,
   const ArrayDimensions* dimensions,
-  const std::function<size_t(const ZarrDimension&)>& parts_along_dimension,
+  const DimensionPartsFun& parts_along_dimension,
   std::vector<std::unique_ptr<Sink>>& part_sinks)
 {
     if (base_path.starts_with("file://")) {
@@ -90,7 +90,7 @@ zarr::SinkCreator::make_data_sinks(
   std::string_view bucket_name,
   std::string_view base_path,
   const ArrayDimensions* dimensions,
-  const std::function<size_t(const ZarrDimension&)>& parts_along_dimension,
+  const DimensionPartsFun& parts_along_dimension,
   std::vector<std::unique_ptr<Sink>>& part_sinks)
 {
     EXPECT(!base_path.empty(), "Base path must not be empty.");
@@ -140,7 +140,7 @@ std::queue<std::string>
 zarr::SinkCreator::make_data_sink_paths_(
   std::string_view base_path,
   const ArrayDimensions* dimensions,
-  const std::function<size_t(const ZarrDimension&)>& parts_along_dimension,
+  const DimensionPartsFun& parts_along_dimension,
   bool create_directories)
 {
     std::queue<std::string> paths;

--- a/src/streaming/sink.creator.hh
+++ b/src/streaming/sink.creator.hh
@@ -52,7 +52,7 @@ class SinkCreator
     [[nodiscard]] bool make_data_sinks(
       std::string_view base_path,
       const ArrayDimensions* dimensions,
-      const std::function<size_t(const ZarrDimension&)>& parts_along_dimension,
+      const DimensionPartsFun& parts_along_dimension,
       std::vector<std::unique_ptr<Sink>>& part_sinks);
 
     /**
@@ -70,7 +70,7 @@ class SinkCreator
       std::string_view bucket_name,
       std::string_view base_path,
       const ArrayDimensions* dimensions,
-      const std::function<size_t(const ZarrDimension&)>& parts_along_dimension,
+      const DimensionPartsFun& parts_along_dimension,
       std::vector<std::unique_ptr<Sink>>& part_sinks);
 
     /**
@@ -120,7 +120,7 @@ class SinkCreator
     std::queue<std::string> make_data_sink_paths_(
       std::string_view base_path,
       const ArrayDimensions* dimensions,
-      const std::function<size_t(const ZarrDimension&)>& parts_along_dimension,
+      const DimensionPartsFun& parts_along_dimension,
       bool create_directories);
 
     std::vector<std::string> make_metadata_sink_paths_(

--- a/src/streaming/zarr.dimension.hh
+++ b/src/streaming/zarr.dimension.hh
@@ -2,6 +2,7 @@
 
 #include "zarr.types.h"
 
+#include <functional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -112,3 +113,5 @@ class ArrayDimensions
     std::vector<ZarrDimension> dims_;
     ZarrDataType dtype_;
 };
+
+using DimensionPartsFun = std::function<size_t(const ZarrDimension&)>;

--- a/src/streaming/zarrv2.array.writer.cpp
+++ b/src/streaming/zarrv2.array.writer.cpp
@@ -72,6 +72,26 @@ zarr::ZarrV2ArrayWriter::ZarrV2ArrayWriter(
 {
 }
 
+std::string
+zarr::ZarrV2ArrayWriter::data_root_() const
+{
+    return config_.store_path + "/" + std::to_string(config_.level_of_detail) +
+           "/" + std::to_string(append_chunk_index_);
+}
+
+std::string
+zarr::ZarrV2ArrayWriter::metadata_path_() const
+{
+    return config_.store_path + "/" + std::to_string(config_.level_of_detail) +
+           "/.zarray";
+}
+
+const DimensionPartsFun
+zarr::ZarrV2ArrayWriter::parts_along_dimension_() const
+{
+    return chunks_along_dimension;
+}
+
 bool
 zarr::ZarrV2ArrayWriter::compress_and_flush_data_()
 {

--- a/src/streaming/zarrv2.array.writer.hh
+++ b/src/streaming/zarrv2.array.writer.hh
@@ -14,7 +14,9 @@ class ZarrV2ArrayWriter final : public ArrayWriter
                       std::shared_ptr<S3ConnectionPool> s3_connection_pool);
 
   private:
-    ZarrVersion version_() const override { return ZarrVersion_2; };
+    std::string data_root_() const override;
+    std::string metadata_path_() const override;
+    const DimensionPartsFun parts_along_dimension_() const override;
     bool compress_and_flush_data_() override;
     bool write_array_metadata_() override;
     bool should_rollover_() const override;

--- a/src/streaming/zarrv3.array.writer.cpp
+++ b/src/streaming/zarrv3.array.writer.cpp
@@ -89,6 +89,26 @@ zarr::ZarrV3ArrayWriter::ZarrV3ArrayWriter(
     }
 }
 
+std::string
+zarr::ZarrV3ArrayWriter::data_root_() const
+{
+    return config_.store_path + "/" + std::to_string(config_.level_of_detail) +
+           "/c/" + std::to_string(append_chunk_index_);
+}
+
+std::string
+zarr::ZarrV3ArrayWriter::metadata_path_() const
+{
+    return config_.store_path + "/" + std::to_string(config_.level_of_detail) +
+           "/zarr.json";
+}
+
+const DimensionPartsFun
+zarr::ZarrV3ArrayWriter::parts_along_dimension_() const
+{
+    return shards_along_dimension;
+}
+
 bool
 zarr::ZarrV3ArrayWriter::compress_and_flush_data_()
 {

--- a/src/streaming/zarrv3.array.writer.hh
+++ b/src/streaming/zarrv3.array.writer.hh
@@ -18,7 +18,9 @@ struct ZarrV3ArrayWriter : public ArrayWriter
     std::vector<std::vector<uint64_t>> shard_tables_;
     uint32_t flushed_count_;
 
-    ZarrVersion version_() const override { return ZarrVersion_3; }
+    std::string data_root_() const override;
+    std::string metadata_path_() const override;
+    const DimensionPartsFun parts_along_dimension_() const override;
     bool compress_and_flush_data_() override;
     bool write_array_metadata_() override;
     bool should_rollover_() const override;

--- a/tests/unit-tests/array-writer-write-frame-to-chunks.cpp
+++ b/tests/unit-tests/array-writer-write-frame-to-chunks.cpp
@@ -13,7 +13,12 @@ class TestWriter : public zarr::ArrayWriter
     }
 
   private:
-    ZarrVersion version_() const override { return ZarrVersionCount; }
+    std::string data_root_() const override { return ""; }
+    std::string metadata_path_() const override { return ""; }
+    const DimensionPartsFun parts_along_dimension_() const override
+    {
+        return {};
+    }
     bool should_rollover_() const override { return false; }
     bool compress_and_flush_data_() override { return true; }
     bool write_array_metadata_() override { return true; }


### PR DESCRIPTION
- Removes `ArrayWriter::version_()`
- Creates `ArrayWriter::data_root_()`, `ArrayWriter::metadata_path_()`, and `ArrayWriter::parts_along_dimension_()`

Gets rid of some ugly code that depended on the output of `version_()` in switch statements. Instead, each subclass must implement the new methods.