### PR TITLE
Append can take multiple frames

### DIFF
--- a/include/acquire.zarr.h
+++ b/include/acquire.zarr.h
@@ -87,7 +87,8 @@ extern "C"
 
     /**
      * @brief Destroy a Zarr stream.
-     * @details This function frees the memory allocated for the Zarr stream.
+     * @details This function waits for all pending writes to complete and frees the 
+     * memory allocated for the Zarr stream.
      * @param stream The Zarr stream struct to destroy.
      */
     void ZarrStream_destroy(ZarrStream* stream);

--- a/include/acquire.zarr.h
+++ b/include/acquire.zarr.h
@@ -95,11 +95,12 @@ extern "C"
     /**
      * @brief Append data to the Zarr stream.
      * @details This function will block while chunks are compressed and written
-     * to the store. It will return when all data has been written.
+     * to the store. It will return when all data has been written. Multiple frames
+     * can be appended in a single call.
      * @param[in, out] stream The Zarr stream struct.
      * @param[in] data The data to append.
-     * @param[in] bytes_in The number of bytes in @p data. It should be at least
-     * the size of a single frame.
+     * @param[in] bytes_in The number of bytes in @p data. This can be the size of
+     * one or multiple frames, but must be a multiple of the frame size.
      * @param[out] bytes_out The number of bytes written to the stream.
      * @return ZarrStatusCode_Success on success, or an error code on failure.
      */

--- a/include/acquire.zarr.h
+++ b/include/acquire.zarr.h
@@ -100,8 +100,8 @@ extern "C"
      * can be appended in a single call.
      * @param[in, out] stream The Zarr stream struct.
      * @param[in] data The data to append.
-     * @param[in] bytes_in The number of bytes in @p data. This can be the size of
-     * one or multiple frames, but must be a multiple of the frame size.
+     * @param[in] bytes_in The number of bytes in @p data. This can be any
+     * nonnegative integer. On a value of 0, this function will immediately return.
      * @param[out] bytes_out The number of bytes written to the stream.
      * @return ZarrStatusCode_Success on success, or an error code on failure.
      */

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -9,6 +9,7 @@ set(tests
         stream-zarr-v3-compressed-to-filesystem
         stream-zarr-v3-raw-to-s3
         stream-zarr-v3-compressed-to-s3
+        stream-zarr-v3-multi-frame-append
 )
 
 foreach (name ${tests})

--- a/tests/integration/stream-zarr-v3-multi-frame-append.cpp
+++ b/tests/integration/stream-zarr-v3-multi-frame-append.cpp
@@ -1,0 +1,161 @@
+#include "acquire.zarr.h"
+#include "test.macros.hh"
+#include <filesystem>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+static const size_t array_width = 64;
+static const size_t array_height = 48;
+static const size_t frames_to_acquire = 10;
+static const size_t frames_per_append = 3;
+static const fs::path test_path = "multi-frame-test.zarr";
+
+static ZarrStream* 
+setup() {
+    ZarrStreamSettings settings = {  
+        .store_path = test_path.string().c_str(),
+        .version = ZarrVersion_3,
+        .data_type = ZarrDataType_uint16,
+    };
+
+    CHECK(ZarrStatusCode_Success == 
+          ZarrStreamSettings_create_dimension_array(&settings, 3));
+
+    // Configure dimensions [t, y, x]
+    settings.dimensions[0] = {
+        .name = "t",
+        .type = ZarrDimensionType_Time,
+        .array_size_px = 0, // Append dimension
+        .chunk_size_px = 5,
+        .shard_size_chunks = 2,
+    };
+
+    settings.dimensions[1] = {
+        .name = "y",
+        .type = ZarrDimensionType_Space,
+        .array_size_px = array_height,
+        .chunk_size_px = 16,
+        .shard_size_chunks = 2,
+    };
+
+    settings.dimensions[2] = {
+        .name = "x",
+        .type = ZarrDimensionType_Space,
+        .array_size_px = array_width,
+        .chunk_size_px = 16,
+        .shard_size_chunks = 2,
+    };
+
+    auto* stream = ZarrStream_create(&settings);
+    ZarrStreamSettings_destroy_dimension_array(&settings);
+    CHECK(stream != nullptr);
+    return stream;
+}
+
+static void
+verify_data() {
+    // Basic structure verification
+    CHECK(fs::exists(test_path));
+    CHECK(fs::exists(test_path / "zarr.json")); // Check zarr metadata exists
+    
+    // Verify the final number of frames by checking the .zarray metadata
+    const fs::path zarray_path = test_path / ".zarray";
+    CHECK(fs::exists(zarray_path));
+    CHECK(fs::file_size(zarray_path) > 0);
+
+    // Count the number of shard files in the chunks directory
+    const fs::path chunks_path = test_path / "c";
+    size_t shard_count = 0;
+    for (const auto& entry : fs::directory_iterator(chunks_path)) {
+        if (entry.is_regular_file() && entry.path().extension() == ".shard") {
+            shard_count++;
+        }
+    }
+    
+    // We should have at least one shard file
+    CHECK(shard_count > 0);
+
+    // Calculate expected number of chunks based on our parameters
+    const size_t expected_frames = frames_to_acquire;
+    const size_t chunk_size_t = 5; // From settings.dimensions[0].chunk_size_px
+    const size_t expected_chunks = (expected_frames + chunk_size_t - 1) / chunk_size_t;
+    
+    // Log some diagnostic information
+    LOG_DEBUG("Found ", shard_count, " shard files");
+    LOG_DEBUG("Expected ", expected_frames, " frames in ", expected_chunks, " chunks");
+}
+
+int
+main()
+{
+    Zarr_set_log_level(ZarrLogLevel_Debug);
+
+    auto* stream = setup();
+    const size_t frame_size = array_width * array_height * sizeof(uint16_t);
+    const size_t multi_frame_size = frame_size * frames_per_append;
+    
+    std::vector<uint16_t> multi_frame_data(array_width * array_height * frames_per_append);
+    int retval = 1;
+
+    try {
+        // Test 1: Append multiple complete frames
+        size_t bytes_out;
+        for (auto i = 0; i < frames_to_acquire; i += frames_per_append) {
+            // Fill multi-frame buffer with test pattern
+            for (size_t f = 0; f < frames_per_append; ++f) {
+                const size_t frame_offset = f * array_width * array_height;
+                const uint16_t frame_value = static_cast<uint16_t>(i + f);
+                std::fill(multi_frame_data.begin() + frame_offset,
+                         multi_frame_data.begin() + frame_offset + (array_width * array_height),
+                         frame_value);
+            }
+
+            ZarrStatusCode status = ZarrStream_append(
+                stream,
+                multi_frame_data.data(),
+                multi_frame_size,
+                &bytes_out);
+
+            EXPECT(status == ZarrStatusCode_Success,
+                   "Failed to append frames ",
+                   i,
+                   "-",
+                   i + frames_per_append - 1);
+            EXPECT_EQ(size_t, bytes_out, multi_frame_size);
+        }
+
+        // Test 2: Append partial frames (should fail)
+        const size_t partial_size = frame_size / 2;
+        ZarrStatusCode status = ZarrStream_append(
+            stream,
+            multi_frame_data.data(),
+            partial_size,
+            &bytes_out);
+        EXPECT(status != ZarrStatusCode_Success,
+               "Partial frame append should fail");
+
+        // Test 3: Append non-multiple of frame size (should fail)
+        const size_t invalid_size = frame_size + (frame_size / 2);
+        status = ZarrStream_append(
+            stream,
+            multi_frame_data.data(),
+            invalid_size,
+            &bytes_out);
+        EXPECT(status != ZarrStatusCode_Success,
+               "Non-multiple of frame size append should fail");
+
+        ZarrStream_destroy(stream);
+
+        verify_data();
+
+        // Clean up
+        fs::remove_all(test_path);
+
+        retval = 0;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Caught exception: ", e.what());
+    }
+
+    return retval;
+} 

--- a/tests/integration/stream-zarr-v3-multi-frame-append.cpp
+++ b/tests/integration/stream-zarr-v3-multi-frame-append.cpp
@@ -13,10 +13,12 @@ static const fs::path test_path = "multi-frame-test.zarr";
 
 static ZarrStream* 
 setup() {
+    const auto test_path_str = test_path.string();
+
     ZarrStreamSettings settings = {  
-        .store_path = test_path.string().c_str(),
-        .version = ZarrVersion_3,
+        .store_path = test_path_str.c_str(),
         .data_type = ZarrDataType_uint16,
+        .version = ZarrVersion_3,
     };
 
     CHECK(ZarrStatusCode_Success == 


### PR DESCRIPTION
I was looking into whether `ZarrStream_append()` could take multiple frames, and I believe it can. This PR

- updates the documentation
- adds a test
