### PR TITLE
add doi

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,18 @@
+authors:
+- affiliation: Chan Zuckerberg Initiative (United States)
+  family-names: Liddell
+  given-names: Alan
+- affiliation: Chan Zuckerberg Initiative (United States)
+  family-names: Eskesen
+  given-names: Justin
+- affiliation: Chan Zuckerberg Initiative (United States)
+  family-names: Clack
+  given-names: Nathan
+  orcid: 0000-0001-6236-9282
+cff-version: 1.2.0
+date-released: '2025-02-06'
+doi: 10.5280/zenodo.14828040
+license:
+- apache-2.0
+title: 'acquire-zarr: Streaming directly to Zarr on the file system or cloud'
+type: software

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14828041.svg)](https://doi.org/10.5281/zenodo.14828041)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14828040.svg)](https://doi.org/10.5281/zenodo.14828040)
 
 from python.tests.test_stream import store_path
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14828040.svg)](https://doi.org/10.5281/zenodo.14828040)
 
-from python.tests.test_stream import store_path
-
 # Acquire Zarr streaming library
 
 [![Build](https://github.com/acquire-project/acquire-zarr/actions/workflows/build.yml/badge.svg)](https://github.com/acquire-project/acquire-zarr/actions/workflows/build.yml)
@@ -9,6 +7,10 @@ from python.tests.test_stream import store_path
 [![Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://acquire-imaging.zulipchat.com/)
 
 This library supports chunked, compressed, multiscale streaming to [Zarr][], with [OME-NGFF metadata].
+
+This code builds targets for python and C.
+
+For python: `pip install acquire-zarr`
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14828041.svg)](https://doi.org/10.5281/zenodo.14828041)
+
 from python.tests.test_stream import store_path
 
 # Acquire Zarr streaming library


### PR DESCRIPTION
I made a [doi](https://doi.org/10.5281/zenodo.14828040) for acquire-zarr corresponding to the v0.1 release. This PR adds a badge to the README.

:star: Please click through the doi and confirm the authors, title, and affiliations look right.

fwiw there's some kind of github zenodo integration we could possibly do - more info [here](https://cassgvp.github.io/github-for-collaborative-documentation/docs/tut/6-Zenodo-integration.html).