### PR TITLE
Support OME-NGFF 0.5 in Zarr V3

### DIFF
--- a/examples/zarrv3-raw-s3.c
+++ b/examples/zarrv3-raw-s3.c
@@ -8,9 +8,9 @@ int main() {
     // Configure S3
     ZarrS3Settings s3 = {
         .endpoint = "http://localhost:9000",
-        .bucket_name = "acquire-test",
-        .access_key_id = "A2KA3o0MNtZQZWiVC5my",
-        .secret_access_key = "Kt8898E4KhMNyX4HeSVQNaz8QBRbcmyIbQwNCEzw"
+        .bucket_name = "mybucket",
+        .access_key_id = "myaccesskey",
+        .secret_access_key = "mysecretkey"
     };
 
     // Configure stream settings

--- a/examples/zarrv3-raw-s3.c
+++ b/examples/zarrv3-raw-s3.c
@@ -8,9 +8,9 @@ int main() {
     // Configure S3
     ZarrS3Settings s3 = {
         .endpoint = "http://localhost:9000",
-        .bucket_name = "mybucket",
-        .access_key_id = "myaccesskey",
-        .secret_access_key = "mysecretkey"
+        .bucket_name = "acquire-test",
+        .access_key_id = "A2KA3o0MNtZQZWiVC5my",
+        .secret_access_key = "Kt8898E4KhMNyX4HeSVQNaz8QBRbcmyIbQwNCEzw"
     };
 
     // Configure stream settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ testing = [
     "ruff",
     "s3fs",
     "tifffile",
-    "zarr==3.0.0",
+    "zarr",
     "python-dotenv",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ testing = [
     "ruff",
     "s3fs",
     "tifffile",
-    "zarr",
+    "zarr>=3.0.0",
     "python-dotenv",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acquire-zarr"
-version = "0.2.1"
+version = "0.2.2"
 description = "Performant streaming to Zarr storage, on filesystem or cloud"
 authors = [
     {name = "Alan Liddell", email = "aliddell@chanzuckerberg.com"}

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -128,7 +128,7 @@ def validate_v3_metadata(store_path: Path):
         assert data["node_type"] == "group"
         assert data["consolidated_metadata"] is None
 
-        axes = data["attributes"]["multiscales"][0]["axes"]
+        axes = data["attributes"]["ome"]["multiscales"][0]["axes"]
         assert axes[0]["name"] == "t"
         assert axes[0]["type"] == "time"
 

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -742,7 +742,8 @@ ZarrStream_s::write_group_metadata_()
 
         metadata_key = ".zgroup";
     } else {
-        metadata["attributes"]["multiscales"] = make_multiscale_metadata_();
+        const auto multiscales = make_multiscale_metadata_();
+        metadata["attributes"]["ome"]["multiscales"] = multiscales;
         metadata["zarr_format"] = 3;
         metadata["consolidated_metadata"] = nullptr;
         metadata["node_type"] = "group";
@@ -827,7 +828,10 @@ nlohmann::json
 ZarrStream_s::make_multiscale_metadata_() const
 {
     nlohmann::json multiscales;
-    multiscales[0]["version"] = "0.4";
+    multiscales[0]["version"] = version_ == ZarrVersion_2
+                                  ? "0.4" // 0.5 does not support Zarr V2
+                                  : "0.5";
+    multiscales[0]["name"] = "/";
 
     auto& axes = multiscales[0]["axes"];
     for (auto i = 0; i < dimensions_->ndims(); ++i) {

--- a/src/streaming/zarr.stream.hh
+++ b/src/streaming/zarr.stream.hh
@@ -104,7 +104,7 @@ struct ZarrStream_s
     [[nodiscard]] bool write_external_metadata_();
 
     /** @brief Construct OME metadata pertaining to the multiscale pyramid. */
-    [[nodiscard]] nlohmann::json make_multiscale_metadata_() const;
+    [[nodiscard]] nlohmann::json make_ome_metadata_() const;
 
     size_t write_frame_(ConstByteSpan data);
     void write_multiscale_frames_(ConstByteSpan data);

--- a/tests/integration/stream-zarr-v2-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v2-compressed-to-filesystem.cpp
@@ -83,6 +83,11 @@ void
 verify_base_metadata(const nlohmann::json& meta)
 {
     const auto multiscales = meta["multiscales"][0];
+    const auto ngff_version = multiscales["version"].get<std::string>();
+    EXPECT(ngff_version == "0.4",
+           "Expected version to be '0.4', but got '",
+           ngff_version,
+           "'");
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v2-compressed-to-s3.cpp
+++ b/tests/integration/stream-zarr-v2-compressed-to-s3.cpp
@@ -216,6 +216,11 @@ void
 verify_base_metadata(const nlohmann::json& meta)
 {
     const auto multiscales = meta["multiscales"][0];
+    const auto ngff_version = multiscales["version"].get<std::string>();
+    EXPECT(ngff_version == "0.4",
+           "Expected version to be '0.4', but got '",
+           ngff_version,
+           "'");
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v2-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v2-raw-to-filesystem.cpp
@@ -76,6 +76,11 @@ void
 verify_base_metadata(const nlohmann::json& meta)
 {
     const auto multiscales = meta["multiscales"][0];
+    const auto ngff_version = multiscales["version"].get<std::string>();
+    EXPECT(ngff_version == "0.4",
+           "Expected version to be '0.4', but got '",
+           ngff_version,
+           "'");
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v2-raw-to-s3.cpp
+++ b/tests/integration/stream-zarr-v2-raw-to-s3.cpp
@@ -209,6 +209,11 @@ void
 verify_base_metadata(const nlohmann::json& meta)
 {
     const auto multiscales = meta["multiscales"][0];
+    const auto ngff_version = multiscales["version"].get<std::string>();
+    EXPECT(ngff_version == "0.4",
+           "Expected version to be '0.4', but got '",
+           ngff_version,
+           "'");
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
@@ -108,7 +108,7 @@ verify_group_metadata(const nlohmann::json& meta)
            "Expected consolidated_metadata to be null");
 
     // multiscales metadata
-    const auto multiscales = meta["attributes"]["multiscales"][0];
+    const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
@@ -107,9 +107,10 @@ verify_group_metadata(const nlohmann::json& meta)
     EXPECT(meta["consolidated_metadata"].is_null(),
            "Expected consolidated_metadata to be null");
 
-    // multiscales metadata
-    const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
-    const auto ngff_version = multiscales["version"].get<std::string>();
+    // OME metadata
+    const auto ome = meta["attributes"]["ome"];
+    const auto multiscales = ome["multiscales"][0];
+    const auto ngff_version = ome["version"].get<std::string>();
     EXPECT(ngff_version == "0.5",
            "Expected version to be '0.5', but got '",
            ngff_version,

--- a/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
@@ -109,6 +109,11 @@ verify_group_metadata(const nlohmann::json& meta)
 
     // multiscales metadata
     const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
+    const auto ngff_version = multiscales["version"].get<std::string>();
+    EXPECT(ngff_version == "0.5",
+           "Expected version to be '0.5', but got '",
+           ngff_version,
+           "'");
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
@@ -248,9 +248,10 @@ verify_group_metadata(const nlohmann::json& meta)
     EXPECT(meta["consolidated_metadata"].is_null(),
            "Expected consolidated_metadata to be null");
 
-    // multiscales metadata
-    const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
-    const auto ngff_version = multiscales["version"].get<std::string>();
+    // OME metadata
+    const auto ome = meta["attributes"]["ome"];
+    const auto multiscales = ome["multiscales"][0];
+    const auto ngff_version = ome["version"].get<std::string>();
     EXPECT(ngff_version == "0.5",
            "Expected version to be '0.5', but got '",
            ngff_version,

--- a/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
@@ -249,7 +249,7 @@ verify_group_metadata(const nlohmann::json& meta)
            "Expected consolidated_metadata to be null");
 
     // multiscales metadata
-    const auto multiscales = meta["attributes"]["multiscales"][0];
+    const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
@@ -250,6 +250,11 @@ verify_group_metadata(const nlohmann::json& meta)
 
     // multiscales metadata
     const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
+    const auto ngff_version = multiscales["version"].get<std::string>();
+    EXPECT(ngff_version == "0.5",
+           "Expected version to be '0.5', but got '",
+           ngff_version,
+           "'");
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
@@ -68,19 +68,30 @@ setup()
 
     ZarrDimensionProperties* dim;
     dim = settings.dimensions;
-    *dim = DIM("t", ZarrDimensionType_Time, array_timepoints, chunk_timepoints, shard_timepoints);
+    *dim = DIM("t",
+               ZarrDimensionType_Time,
+               array_timepoints,
+               chunk_timepoints,
+               shard_timepoints);
 
     dim = settings.dimensions + 1;
-    *dim = DIM("c", ZarrDimensionType_Channel, array_channels, chunk_channels, shard_channels);
+    *dim = DIM("c",
+               ZarrDimensionType_Channel,
+               array_channels,
+               chunk_channels,
+               shard_channels);
 
     dim = settings.dimensions + 2;
-    *dim = DIM("z", ZarrDimensionType_Space, array_planes, chunk_planes, shard_planes);
+    *dim = DIM(
+      "z", ZarrDimensionType_Space, array_planes, chunk_planes, shard_planes);
 
     dim = settings.dimensions + 3;
-    *dim = DIM("y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
+    *dim = DIM(
+      "y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
 
     dim = settings.dimensions + 4;
-    *dim = DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
+    *dim =
+      DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -101,7 +112,7 @@ verify_group_metadata(const nlohmann::json& meta)
            "Expected consolidated_metadata to be null");
 
     // multiscales metadata
-    const auto multiscales = meta["attributes"]["multiscales"][0];
+    const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
@@ -115,18 +126,21 @@ verify_group_metadata(const nlohmann::json& meta)
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
-    EXPECT(type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(
+      type == "channel", "Expected type to be 'channel', but got '", type, "'");
 
     name = axes[2]["name"];
     type = axes[2]["type"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
-    EXPECT(type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
     unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
-    EXPECT(type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
     EXPECT(unit == "micrometer",
            "Expected unit to be 'micrometer', but got '",
            unit,
@@ -136,7 +150,8 @@ verify_group_metadata(const nlohmann::json& meta)
     type = axes[4]["type"];
     unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
-    EXPECT(type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
     EXPECT(unit == "micrometer",
            "Expected unit to be 'micrometer', but got '",
            unit,
@@ -150,7 +165,8 @@ verify_group_metadata(const nlohmann::json& meta)
       datasets["coordinateTransformations"][0];
 
     type = coordinate_transformations["type"].get<std::string>();
-    EXPECT(type == "scale", "Expected type to be 'scale', but got '", type, "'");
+    EXPECT(
+      type == "scale", "Expected type to be 'scale', but got '", type, "'");
 
     const auto scale = coordinate_transformations["scale"];
     EXPECT_EQ(size_t, scale.size(), 5);

--- a/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
@@ -113,6 +113,11 @@ verify_group_metadata(const nlohmann::json& meta)
 
     // multiscales metadata
     const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
+    const auto ngff_version = multiscales["version"].get<std::string>();
+    EXPECT(ngff_version == "0.5",
+           "Expected version to be '0.5', but got '",
+           ngff_version,
+           "'");
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
@@ -111,9 +111,10 @@ verify_group_metadata(const nlohmann::json& meta)
     EXPECT(meta["consolidated_metadata"].is_null(),
            "Expected consolidated_metadata to be null");
 
-    // multiscales metadata
-    const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
-    const auto ngff_version = multiscales["version"].get<std::string>();
+    // OME metadata
+    const auto ome = meta["attributes"]["ome"];
+    const auto multiscales = ome["multiscales"][0];
+    const auto ngff_version = ome["version"].get<std::string>();
     EXPECT(ngff_version == "0.5",
            "Expected version to be '0.5', but got '",
            ngff_version,

--- a/tests/integration/stream-zarr-v3-raw-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-s3.cpp
@@ -233,7 +233,7 @@ verify_group_metadata(const nlohmann::json& meta)
            "Expected consolidated_metadata to be null");
 
     // multiscales metadata
-    const auto multiscales = meta["attributes"]["multiscales"][0];
+    const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v3-raw-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-s3.cpp
@@ -234,6 +234,11 @@ verify_group_metadata(const nlohmann::json& meta)
 
     // multiscales metadata
     const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
+    const auto ngff_version = multiscales["version"].get<std::string>();
+    EXPECT(ngff_version == "0.5",
+           "Expected version to be '0.5', but got '",
+           ngff_version,
+           "'");
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);

--- a/tests/integration/stream-zarr-v3-raw-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-s3.cpp
@@ -232,9 +232,10 @@ verify_group_metadata(const nlohmann::json& meta)
     EXPECT(meta["consolidated_metadata"].is_null(),
            "Expected consolidated_metadata to be null");
 
-    // multiscales metadata
-    const auto multiscales = meta["attributes"]["ome"]["multiscales"][0];
-    const auto ngff_version = multiscales["version"].get<std::string>();
+    // OME metadata
+    const auto ome = meta["attributes"]["ome"];
+    const auto multiscales = ome["multiscales"][0];
+    const auto ngff_version = ome["version"].get<std::string>();
     EXPECT(ngff_version == "0.5",
            "Expected version to be '0.5', but got '",
            ngff_version,


### PR DESCRIPTION
The actual update is simple -- the multiscales metadata remains mostly the same, but is now under `attributes/ome` rather than just `attributes`. Also adds an overlooked `name` field to the `multiscales` metadata, which SHOULD be there by the spec.