### PR TITLE
Create and destroy sinks on demand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acquire-zarr"
-version = "0.2.2"
+version = "0.2.3"
 description = "Performant streaming to Zarr storage, on filesystem or cloud"
 authors = [
     {name = "Alan Liddell", email = "aliddell@chanzuckerberg.com"}

--- a/src/streaming/array.writer.cpp
+++ b/src/streaming/array.writer.cpp
@@ -282,22 +282,10 @@ zarr::ArrayWriter::should_flush_() const
 }
 
 void
-zarr::ArrayWriter::close_sinks_()
-{
-    for (auto i = 0; i < data_sinks_.size(); ++i) {
-        EXPECT(finalize_sink(std::move(data_sinks_[i])),
-               "Failed to finalize sink ",
-               i);
-    }
-    data_sinks_.clear();
-}
-
-void
 zarr::ArrayWriter::rollover_()
 {
     LOG_DEBUG("Rolling over");
 
-    data_paths_.clear();
     close_sinks_();
     ++append_chunk_index_;
 }

--- a/src/streaming/array.writer.cpp
+++ b/src/streaming/array.writer.cpp
@@ -198,7 +198,7 @@ zarr::ArrayWriter::make_metadata_sink_()
     metadata_sink_ =
       is_s3_array_()
         ? make_s3_sink(*config_.bucket_name, metadata_path, s3_connection_pool_)
-        : make_file_sink(metadata_path);
+        : make_file_sink(metadata_path, true);
 
     if (!metadata_sink_) {
         LOG_ERROR("Failed to create metadata sink: ", metadata_path);

--- a/src/streaming/array.writer.hh
+++ b/src/streaming/array.writer.hh
@@ -63,6 +63,7 @@ class ArrayWriter
     std::vector<ByteVector> data_buffers_;
 
     /// Filesystem
+    std::vector<std::string> data_paths_;
     std::vector<std::unique_ptr<Sink>> data_sinks_;
     std::unique_ptr<Sink> metadata_sink_;
 
@@ -91,7 +92,7 @@ class ArrayWriter
     virtual std::string metadata_path_() const = 0;
     virtual const DimensionPartsFun parts_along_dimension_() const = 0;
 
-    [[nodiscard]] bool make_data_sinks_();
+    void make_data_paths_();
     [[nodiscard]] bool make_metadata_sink_();
     virtual void make_buffers_() = 0;
 

--- a/src/streaming/array.writer.hh
+++ b/src/streaming/array.writer.hh
@@ -64,7 +64,6 @@ class ArrayWriter
 
     /// Filesystem
     std::vector<std::string> data_paths_;
-    std::vector<std::unique_ptr<Sink>> data_sinks_;
     std::unique_ptr<Sink> metadata_sink_;
 
     /// Multithreading
@@ -108,7 +107,7 @@ class ArrayWriter
 
     [[nodiscard]] virtual bool write_array_metadata_() = 0;
 
-    void close_sinks_();
+    virtual void close_sinks_() = 0;
 
     friend bool finalize_array(std::unique_ptr<ArrayWriter>&& writer);
 };

--- a/src/streaming/definitions.hh
+++ b/src/streaming/definitions.hh
@@ -8,3 +8,5 @@ using BytePtr = std::byte*;
 
 using ByteSpan = std::span<std::byte>;
 using ConstByteSpan = std::span<const std::byte>;
+
+constexpr int MAX_CONCURRENT_FILES = 256;

--- a/src/streaming/file.sink.cpp
+++ b/src/streaming/file.sink.cpp
@@ -5,8 +5,9 @@
 
 namespace fs = std::filesystem;
 
-zarr::FileSink::FileSink(std::string_view filename)
-: file_(filename.data(), std::ios::binary | std::ios::trunc)
+zarr::FileSink::FileSink(std::string_view filename, bool truncate)
+  : file_(filename.data(),
+          truncate ? (std::ios::binary | std::ios::trunc) : std::ios::binary)
 {
     EXPECT(file_.is_open(), "Failed to open file ", filename);
 }

--- a/src/streaming/file.sink.cpp
+++ b/src/streaming/file.sink.cpp
@@ -1,4 +1,5 @@
 #include "file.sink.hh"
+#include "macros.hh"
 
 #include <filesystem>
 
@@ -7,6 +8,7 @@ namespace fs = std::filesystem;
 zarr::FileSink::FileSink(std::string_view filename)
 : file_(filename.data(), std::ios::binary | std::ios::trunc)
 {
+    EXPECT(file_.is_open(), "Failed to open file ", filename);
 }
 
 bool

--- a/src/streaming/file.sink.hh
+++ b/src/streaming/file.sink.hh
@@ -9,7 +9,7 @@ namespace zarr {
 class FileSink : public Sink
 {
   public:
-    explicit FileSink(std::string_view filename);
+    FileSink(std::string_view filename, bool truncate = true);
 
     bool write(size_t offset, std::span<const std::byte> data) override;
 

--- a/src/streaming/sink.cpp
+++ b/src/streaming/sink.cpp
@@ -81,7 +81,7 @@ make_file_sinks(std::vector<std::string>& file_paths,
 
             try {
                 if (all_successful) {
-                    *psink = std::make_unique<zarr::FileSink>(filename);
+                    *psink = std::make_unique<zarr::FileSink>(filename, true);
                 }
                 success = true;
             } catch (const std::exception& exc) {
@@ -146,7 +146,7 @@ make_file_sinks(
                      try {
                          if (all_successful) {
                              *psink =
-                               std::make_unique<zarr::FileSink>(filename);
+                               std::make_unique<zarr::FileSink>(filename, true);
                          }
                          success = true;
                      } catch (const std::exception& exc) {
@@ -351,9 +351,8 @@ zarr::make_dirs(const std::vector<std::string>& dir_paths,
     return static_cast<bool>(all_successful);
 }
 
-
 std::unique_ptr<zarr::Sink>
-zarr::make_file_sink(std::string_view file_path)
+zarr::make_file_sink(std::string_view file_path, bool truncate)
 {
     if (file_path.starts_with("file://")) {
         file_path = file_path.substr(7);
@@ -375,7 +374,7 @@ zarr::make_file_sink(std::string_view file_path)
         }
     }
 
-    return std::make_unique<FileSink>(file_path);
+    return std::make_unique<FileSink>(file_path, truncate);
 }
 
 bool

--- a/src/streaming/sink.hh
+++ b/src/streaming/sink.hh
@@ -76,12 +76,13 @@ make_dirs(const std::vector<std::string>& dir_paths,
 /**
  * @brief Create a file sink from a path.
  * @param file_path The path to the file.
+ * @param truncate If true, the file is truncated to zero length.
  * @return Pointer to the sink created, or nullptr if the file cannot be
  * opened.
  * @throws std::runtime_error if the file path is not valid.
  */
 std::unique_ptr<Sink>
-make_file_sink(std::string_view file_path);
+make_file_sink(std::string_view file_path, bool truncate);
 
 /**
  * @brief Create a collection of file sinks for a Zarr dataset.

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -803,7 +803,7 @@ ZarrStream_s::write_external_metadata_()
                 s3_settings_->bucket_name, sink_path, s3_connection_pool_));
         } else {
             metadata_sinks_.emplace(metadata_key,
-                                    zarr::make_file_sink(sink_path));
+                                    zarr::make_file_sink(sink_path, true));
         }
     }
 

--- a/src/streaming/zarrv2.array.writer.cpp
+++ b/src/streaming/zarrv2.array.writer.cpp
@@ -193,7 +193,7 @@ zarr::ZarrV2ArrayWriter::compress_and_flush_data_()
                         }
                     }
 
-                    std::unique_ptr<Sink> sink = nullptr;
+                    std::unique_ptr<Sink> sink;
                     semaphore.acquire();
                     try {
                         if (is_s3) {

--- a/src/streaming/zarrv2.array.writer.cpp
+++ b/src/streaming/zarrv2.array.writer.cpp
@@ -152,11 +152,11 @@ zarr::ZarrV2ArrayWriter::compress_and_flush_data_()
               thread_pool_->push_job(
                 std::move([bytes_per_px,
                            bytes_of_raw_chunk,
+                           &compression_params,
                            is_s3,
                            &data_path = data_paths_[i],
                            chunk_ptr = get_chunk_data_(i),
                            &bucket_name,
-                           &compression_params,
                            connection_pool,
                            &semaphore,
                            &latch,
@@ -296,6 +296,12 @@ zarr::ZarrV2ArrayWriter::write_array_metadata_()
     std::span data{ reinterpret_cast<std::byte*>(metadata_str.data()),
                     metadata_str.size() };
     return metadata_sink_->write(0, data);
+}
+
+void
+zarr::ZarrV2ArrayWriter::close_sinks_()
+{
+    data_paths_.clear();
 }
 
 bool

--- a/src/streaming/zarrv2.array.writer.hh
+++ b/src/streaming/zarrv2.array.writer.hh
@@ -21,6 +21,7 @@ class ZarrV2ArrayWriter final : public ArrayWriter
     BytePtr get_chunk_data_(uint32_t index) override;
     bool compress_and_flush_data_() override;
     bool write_array_metadata_() override;
+    void close_sinks_() override;
     bool should_rollover_() const override;
 };
 } // namespace zarr

--- a/src/streaming/zarrv3.array.writer.cpp
+++ b/src/streaming/zarrv3.array.writer.cpp
@@ -497,6 +497,18 @@ zarr::ZarrV3ArrayWriter::write_array_metadata_()
     return metadata_sink_->write(0, data);
 }
 
+void
+zarr::ZarrV3ArrayWriter::close_sinks_()
+{
+    data_paths_.clear();
+
+    for (auto& [path, sink] : s3_data_sinks_) {
+        EXPECT(
+          finalize_sink(std::move(sink)), "Failed to finalize sink at ", path);
+    }
+    s3_data_sinks_.clear();
+}
+
 bool
 zarr::ZarrV3ArrayWriter::should_rollover_() const
 {

--- a/src/streaming/zarrv3.array.writer.hh
+++ b/src/streaming/zarrv3.array.writer.hh
@@ -17,6 +17,8 @@ struct ZarrV3ArrayWriter : public ArrayWriter
     std::vector<std::vector<uint64_t>> shard_tables_;
     uint32_t current_layer_;
 
+    std::unordered_map<std::string, std::unique_ptr<Sink>> s3_data_sinks_;
+
     size_t compute_chunk_offsets_and_defrag_(uint32_t shard_index);
 
     std::string data_root_() const override;
@@ -26,6 +28,7 @@ struct ZarrV3ArrayWriter : public ArrayWriter
     BytePtr get_chunk_data_(uint32_t index) override;
     bool compress_and_flush_data_() override;
     bool write_array_metadata_() override;
+    void close_sinks_() override;
     bool should_rollover_() const override;
 };
 } // namespace zarr

--- a/tests/integration/stream-zarr-v2-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v2-compressed-to-filesystem.cpp
@@ -13,10 +13,10 @@ namespace {
 const std::string test_path =
   (fs::temp_directory_path() / (TEST ".zarr")).string();
 
-const unsigned int array_width = 64, array_height = 48, array_planes = 6,
+const unsigned int array_width = 2048, array_height = 2048, array_planes = 6,
                    array_channels = 8, array_timepoints = 10;
 
-const unsigned int chunk_width = 16, chunk_height = 16, chunk_planes = 2,
+const unsigned int chunk_width = 64, chunk_height = 64, chunk_planes = 2,
                    chunk_channels = 4, chunk_timepoints = 5;
 
 const unsigned int chunks_in_x =

--- a/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
@@ -13,10 +13,10 @@ namespace {
 const std::string test_path =
   (fs::temp_directory_path() / (TEST ".zarr")).string();
 
-const unsigned int array_width = 64, array_height = 48, array_planes = 6,
+const unsigned int array_width = 2048, array_height = 2048, array_planes = 6,
                    array_channels = 8, array_timepoints = 10;
 
-const unsigned int chunk_width = 16, chunk_height = 16, chunk_planes = 2,
+const unsigned int chunk_width = 64, chunk_height = 64, chunk_planes = 2,
                    chunk_channels = 4, chunk_timepoints = 5;
 
 const unsigned int shard_width = 2, shard_height = 1, shard_planes = 1,


### PR DESCRIPTION
Talley [noticed](https://github.com/acquire-project/acquire-zarr/issues/55#issuecomment-2676227165) an issue wherein Zarr datasets with small chunk sizes weren't writing all the data correctly. The reason turned out to be a situation where `FileSink`s would be created but not the underlying files not opened due to OS file handle exhaustion.

This PR fixes the issue by moving the creation of `Sink`s into the immediate context of where they're written, and enforces a limit (via semaphore) on the number of open handles allowed.