### PR TITLE
Remove miniocpp includes from acquire-zarr header files

### DIFF
--- a/src/streaming/s3.connection.hh
+++ b/src/streaming/s3.connection.hh
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <miniocpp/client.h>
-
 #include <condition_variable>
 #include <list>
 #include <memory>
@@ -21,10 +19,18 @@ struct S3Settings
     std::optional<std::string> region;
 };
 
+struct S3Part
+{
+    unsigned int number;
+    std::string etag;
+    size_t size;
+};
+
 class S3Connection
 {
   public:
     explicit S3Connection(const S3Settings& settings);
+    ~S3Connection();
 
     /**
      * @brief Test a connection by listing all buckets at this connection's
@@ -117,11 +123,12 @@ class S3Connection
       std::string_view bucket_name,
       std::string_view object_name,
       std::string_view upload_id,
-      const std::list<minio::s3::Part>& parts);
+      const std::vector<S3Part>& parts);
 
   private:
-    std::unique_ptr<minio::s3::Client> client_;
-    std::unique_ptr<minio::creds::StaticProvider> provider_;
+    struct Impl;
+
+    std::unique_ptr<Impl> impl_;
 };
 
 class S3ConnectionPool

--- a/src/streaming/s3.sink.cpp
+++ b/src/streaming/s3.sink.cpp
@@ -155,7 +155,7 @@ zarr::S3Sink::flush_part_()
     try {
         auto& parts = multipart_upload_->parts;
 
-        minio::s3::Part part;
+        S3Part part;
         part.number = static_cast<unsigned int>(parts.size()) + 1;
 
         std::span data(reinterpret_cast<uint8_t*>(part_buffer_.data()),

--- a/src/streaming/s3.sink.hh
+++ b/src/streaming/s3.sink.hh
@@ -3,8 +3,6 @@
 #include "sink.hh"
 #include "s3.connection.hh"
 
-#include <miniocpp/types.h>
-
 #include <array>
 #include <optional>
 #include <string>
@@ -26,7 +24,7 @@ class S3Sink : public Sink
     struct MultiPartUpload
     {
         std::string upload_id;
-        std::list<minio::s3::Part> parts;
+        std::vector<S3Part> parts;
     };
 
     static constexpr size_t max_part_size_ = 5 << 20;

--- a/tests/unit-tests/s3-connection-upload-multipart-object.cpp
+++ b/tests/unit-tests/s3-connection-upload-multipart-object.cpp
@@ -69,7 +69,7 @@ main()
           conn->create_multipart_object(settings.bucket_name, object_name);
         CHECK(!upload_id.empty());
 
-        std::list<minio::s3::Part> parts;
+        std::vector<zarr::S3Part> parts;
 
         // parts need to be at least 5MiB, except the last part
         std::vector<uint8_t> data(5 << 20, 0);
@@ -82,7 +82,7 @@ main()
               i + 1);
             CHECK(!etag.empty());
 
-            minio::s3::Part part;
+            zarr::S3Part part;
             part.number = i + 1;
             part.etag = etag;
             part.size = data.size();
@@ -102,7 +102,7 @@ main()
               part_number);
             CHECK(!etag.empty());
 
-            minio::s3::Part part;
+            zarr::S3Part part;
             part.number = part_number;
             part.etag = etag;
             part.size = part_size;

--- a/tests/unit-tests/s3-sink-write-multipart.cpp
+++ b/tests/unit-tests/s3-sink-write-multipart.cpp
@@ -1,6 +1,8 @@
 #include "s3.sink.hh"
 #include "unit.test.macros.hh"
 
+#include <miniocpp/client.h>
+
 #include <cstdlib>
 #include <memory>
 

--- a/tests/unit-tests/s3-sink-write.cpp
+++ b/tests/unit-tests/s3-sink-write.cpp
@@ -1,6 +1,8 @@
 #include "s3.sink.hh"
 #include "unit.test.macros.hh"
 
+#include <miniocpp/client.h>
+
 #include <cstdlib>
 
 namespace {


### PR DESCRIPTION
Closes #2. Also plugs a leak of definitions from Windows headers.