### PR TITLE
Fix transposed array bug

### DIFF
--- a/python/acquire-zarr-py.cpp
+++ b/python/acquire-zarr-py.cpp
@@ -109,8 +109,6 @@ log_level_to_str(ZarrLogLevel level)
             return "UNKNOWN";
     }
 }
-
-py::module np;
 } // namespace
 
 class PyZarrS3Settings
@@ -395,9 +393,14 @@ class PyZarrStream
             throw py::error_already_set();
         }
 
-        // Creates a contiguous copy, but only if not already contiguous
-        // https://numpy.org/doc/2.1/reference/generated/numpy.ascontiguousarray.html
-        py::array contiguous_data = np.attr("ascontiguousarray")(image_data);
+        // Create a contiguous copy, but only if needed
+        py::array contiguous_data;
+        if (!(image_data.flags() & py::array::c_style)) {
+            py::module np = py::module::import("numpy");
+            contiguous_data = np.attr("ascontiguousarray")(image_data);
+        } else {
+            contiguous_data = image_data;
+        }
 
         auto buf = contiguous_data.request();
         auto* ptr = (uint8_t*)buf.ptr;
@@ -464,8 +467,6 @@ class PyZarrStream
 
 PYBIND11_MODULE(acquire_zarr, m)
 {
-    np = py::module::import("numpy");
-
     py::options options;
     options.disable_user_defined_docstrings();
     options.disable_function_signatures();

--- a/python/acquire-zarr-py.cpp
+++ b/python/acquire-zarr-py.cpp
@@ -393,7 +393,16 @@ class PyZarrStream
             throw py::error_already_set();
         }
 
-        auto buf = image_data.request();
+        // Create a contiguous copy, but only if needed
+        py::array contiguous_data;
+        if (!(image_data.flags() & py::array::c_style)) {
+            py::module np = py::module::import("numpy");
+            contiguous_data = np.attr("ascontiguousarray")(image_data);
+        } else {
+            contiguous_data = image_data;
+        }
+
+        auto buf = contiguous_data.request();
         auto* ptr = (uint8_t*)buf.ptr;
 
         py::gil_scoped_release release;


### PR DESCRIPTION
Shallowly transposing image arrays (as in `np.transpose()`) and passing them to `stream.append()` fails to write the data in the order the user expects. This PR fixes that by making a contiguous copy, if necessary, and passing that data to `stream.append()`.