### PR TITLE
Fix handling of transposed NumPy arrays in `ZarrStream.append()`

### DIFF
--- a/python/acquire-zarr-py.cpp
+++ b/python/acquire-zarr-py.cpp
@@ -367,13 +367,79 @@ class PyZarrStream
             throw py::error_already_set();
         }
 
-        // Create a contiguous copy, but only if needed
-        py::array contiguous_data;
-        if (!(image_data.flags() & py::array::c_style)) {
+        // if the array is already contiguous, we can just write it out
+        if (image_data.flags() & py::array::c_style) {
+            write_contiguous_data(image_data);
+            return;
+        }
+
+        // just make a copy of smaller (2-dim or less) arrays
+        if (image_data.ndim() <= 2) {
             py::module np = py::module::import("numpy");
-            contiguous_data = np.attr("ascontiguousarray")(image_data);
+            py::array contiguous_data =
+              np.attr("ascontiguousarray")(image_data);
+            write_contiguous_data(contiguous_data);
+            return;
+        }
+
+        // iterate through frames
+        iterate_and_append(image_data, 0, std::vector<py::ssize_t>());
+    }
+
+    // iterate over the indices of the array until we get down to 2 dimensions,
+    // then write the frame
+    void iterate_and_append(const py::array& array,
+                            size_t dim,
+                            std::vector<py::ssize_t> indices)
+    {
+        if (dim == array.ndim() - 2) {
+            // we are down to a 2D frame - we can write it
+            py::array frame = extract_frame(array, indices);
+            write_contiguous_data(frame);
         } else {
-            contiguous_data = image_data;
+            // construct indices for this dimension
+            for (py::ssize_t i = 0; i < array.shape()[dim]; ++i) {
+                indices.push_back(i);
+                iterate_and_append(array, dim + 1, indices);
+                indices.pop_back();
+            }
+        }
+    }
+
+    // extract a 2D frame given the indices for all but the last 2 dimensions
+    py::array extract_frame(const py::array& array,
+                            const std::vector<py::ssize_t>& indices)
+    {
+        // Use Python's slicing to extract the frame
+        py::tuple args(array.ndim());
+
+        // fill the tuple with the indices for higher dimensions...
+        for (size_t i = 0; i < indices.size(); ++i) {
+            args[i] = py::int_(indices[i]);
+        }
+
+        // ... and slices for the last two
+        py::module builtins = py::module::import("builtins");
+        py::object slice_fn = builtins.attr("slice");
+        py::object none = py::none(); // equivalent to : in Python
+
+        args[array.ndim() - 2] = slice_fn(none, none, none);
+        args[array.ndim() - 1] = slice_fn(none, none, none);
+
+        // here's the frame
+        py::object frame = array.attr("__getitem__")(args);
+        return frame.cast<py::array>();
+    }
+
+    void write_contiguous_data(py::array frame)
+    {
+        // double check the frame is C-contiguous
+        py::array contiguous_data;
+        if (!(frame.flags() & py::array::c_style)) {
+            py::module np = py::module::import("numpy");
+            contiguous_data = np.attr("ascontiguousarray")(frame);
+        } else {
+            contiguous_data = frame;
         }
 
         auto buf = contiguous_data.request();
@@ -381,15 +447,21 @@ class PyZarrStream
 
         py::gil_scoped_release release;
 
-        size_t bytes_out;
-        auto status = ZarrStream_append(
-          stream_.get(), ptr, buf.itemsize * buf.size, &bytes_out);
+        size_t bytes_out, bytes_in = buf.itemsize * buf.size;
+        auto status =
+          ZarrStream_append(stream_.get(), ptr, bytes_in, &bytes_out);
 
         py::gil_scoped_acquire acquire;
 
         if (status != ZarrStatusCode_Success) {
             std::string err = "Failed to append data to Zarr stream: " +
                               std::string(Zarr_get_status_message(status));
+            PyErr_SetString(PyExc_RuntimeError, err.c_str());
+            throw py::error_already_set();
+        } else if (bytes_out != bytes_in) {
+            std::string err = "Expected to write " + std::to_string(bytes_in) +
+                              " bytes, wrote " + std::to_string(bytes_out) +
+                              ".";
             PyErr_SetString(PyExc_RuntimeError, err.c_str());
             throw py::error_already_set();
         }


### PR DESCRIPTION
This PR addresses an issue where transposed NumPy arrays would be written incorrectly when passed directly to `append()`. The problem occurs because NumPy's transpose operation creates a view with modified strides rather than rearranging the data in memory, but our C++ code was interpreting the memory linearly. We had previously made a [copy](https://github.com/acquire-project/acquire-zarr/pull/90), assuming data would be small, but of course we have no such guarantee.

## Changes

- Added logic to detect non-contiguous arrays (like those created by `np.transpose()`)
- For smaller, low-dimensional arrays (1D/2D), create a contiguous copy before processing
- For larger multi-dimensional arrays, iterate through frames to conserve memory
- Process each frame individually, ensuring correct memory layout