### PR TITLE
Automatically detect trivial Z dimension when downsampling

### DIFF
--- a/src/streaming/downsampler.cpp
+++ b/src/streaming/downsampler.cpp
@@ -158,11 +158,13 @@ bool
 zarr::Downsampler::is_3d_downsample_() const
 {
     // the width and depth dimensions are always spatial -- if the 3rd dimension
-    // is also spatial, then we downsample in 3 dimensions
+    // is also spatial and nontrivial, then we downsample in 3 dimensions
     const auto& dims = writer_configurations_.at(0).dimensions;
     const auto ndims = dims->ndims();
 
-    return dims->at(ndims - 3).type == ZarrDimensionType_Space;
+    const auto& third_dim = dims->at(ndims - 3);
+    return third_dim.type == ZarrDimensionType_Space &&
+           third_dim.array_size_px > 1;
 }
 
 size_t

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -884,6 +884,8 @@ ZarrStream_s::make_ome_metadata_() const
             const auto base_size = base_dim.array_size_px;
             const auto down_size = down_dim.array_size_px;
             const auto ratio = (base_size + down_size - 1) / down_size;
+
+            // round to the next power of 2 if the ratio isn't an integer
             scales[j] = std::pow(2.0, std::ceil(std::log2(ratio)));
         }
 

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -872,12 +872,20 @@ ZarrStream_s::make_ome_metadata_() const
     };
 
     for (auto i = 1; i < writers_.size(); ++i) {
-        const auto& dim3 = dimensions_->at(ndims - 3);
-        if (dim3.type == ZarrDimensionType_Space) {
-            scales[ndims - 3] = std::pow(2, i);
+        const auto& config = downsampler_->writer_configurations().at(i);
+
+        for (auto j = 0; j < ndims; ++j) {
+            const auto& base_dim = dimensions_->at(j);
+            const auto& down_dim = config.dimensions->at(j);
+            if (base_dim.type != ZarrDimensionType_Space) {
+                continue;
+            }
+
+            const auto base_size = base_dim.array_size_px;
+            const auto down_size = down_dim.array_size_px;
+            const auto ratio = (base_size + down_size - 1) / down_size;
+            scales[j] = std::pow(2.0, std::ceil(std::log2(ratio)));
         }
-        scales[ndims - 2] = std::pow(2, i);
-        scales[ndims - 1] = std::pow(2, i);
 
         multiscales[0]["datasets"].push_back({
           { "path", std::to_string(i) },

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
         stream-zarr-v3-raw-to-s3
         stream-zarr-v3-compressed-to-s3
         stream-zarr-v3-multi-frame-append
+        stream-zarr-v3-multiscale-trivial-3rd-dim
 )
 
 foreach (name ${tests})

--- a/tests/integration/stream-zarr-v3-multiscale-trivial-3rd-dim.cpp
+++ b/tests/integration/stream-zarr-v3-multiscale-trivial-3rd-dim.cpp
@@ -1,0 +1,202 @@
+#include "acquire.zarr.h"
+#include "test.macros.hh"
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <filesystem>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+const std::string test_path =
+  (fs::temp_directory_path() / ("test_ragged_downsampling.zarr")).string();
+
+// Original array dimensions
+const unsigned int array_width = 64;
+const unsigned int array_height = 48;
+const unsigned int array_planes = 1;  // Only 1 plane to test non-3D downsampling
+const unsigned int array_channels = 3;
+const unsigned int array_timepoints = 5;
+
+// Chunk dimensions
+const unsigned int chunk_width = 16;
+const unsigned int chunk_height = 16;
+const unsigned int chunk_planes = 1;
+const unsigned int chunk_channels = 3;
+const unsigned int chunk_timepoints = 5;
+
+// Shard dimensions
+const unsigned int shard_width = 2;
+const unsigned int shard_height = 2;
+const unsigned int shard_planes = 1;
+const unsigned int shard_channels = 1;
+const unsigned int shard_timepoints = 1;
+
+// Derived constants
+const size_t nbytes_px = sizeof(uint16_t);
+const uint32_t frames_to_acquire = array_planes * array_channels * array_timepoints;
+const size_t bytes_of_frame = array_width * array_height * nbytes_px;
+} // namespace
+
+ZarrStream*
+setup()
+{
+    ZarrStreamSettings settings = {
+        .store_path = test_path.c_str(),
+        .s3_settings = nullptr,
+        .multiscale = true,
+        .data_type = ZarrDataType_uint16,
+        .version = ZarrVersion_3,
+        .max_threads = 0, // use all available threads
+    };
+
+    ZarrCompressionSettings compression_settings = {
+        .compressor = ZarrCompressor_Blosc1,
+        .codec = ZarrCompressionCodec_BloscLZ4,
+        .level = 2,
+        .shuffle = 2,
+    };
+    settings.compression_settings = &compression_settings;
+
+    CHECK_OK(ZarrStreamSettings_create_dimension_array(&settings, 5));
+
+    ZarrDimensionProperties* dim;
+    dim = settings.dimensions;
+    *dim = DIM("t",
+               ZarrDimensionType_Time,
+               array_timepoints,
+               chunk_timepoints,
+               shard_timepoints);
+
+    dim = settings.dimensions + 1;
+    *dim = DIM("c",
+               ZarrDimensionType_Channel,
+               array_channels,
+               chunk_channels,
+               shard_channels);
+
+    dim = settings.dimensions + 2;
+    *dim = DIM(
+      "z", ZarrDimensionType_Space, array_planes, chunk_planes, shard_planes);
+
+    dim = settings.dimensions + 3;
+    *dim = DIM(
+      "y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
+
+    dim = settings.dimensions + 4;
+    *dim =
+      DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
+
+    auto* stream = ZarrStream_create(&settings);
+    ZarrStreamSettings_destroy_dimension_array(&settings);
+
+    return stream;
+}
+
+void verify_multiscale_metadata()
+{
+    // Read the group metadata
+    fs::path group_metadata_path = fs::path(test_path) / "zarr.json";
+    EXPECT(fs::is_regular_file(group_metadata_path),
+           "Expected file '", group_metadata_path, "' to exist");
+    
+    std::ifstream f = std::ifstream(group_metadata_path);
+    nlohmann::json group_metadata = nlohmann::json::parse(f);
+    
+    // Verify OME-NGFF multiscale metadata
+    const auto ome = group_metadata["attributes"]["ome"];
+    const auto multiscales = ome["multiscales"][0];
+    const auto datasets = multiscales["datasets"];
+    
+    // We should have 3 resolution levels (base + 2 downsampled)
+    EXPECT_EQ(size_t, datasets.size(), 3);
+
+    for (auto level = 0; level < 3; ++level) {
+        const auto& dataset = datasets[level];
+        const auto path = dataset["path"].get<std::string>();
+        EXPECT(path == std::to_string(level),
+               "Expected path to be '", std::to_string(level), "', but got '", path, "'");
+               
+        const auto coordinate_transformations = dataset["coordinateTransformations"];
+        const auto type = coordinate_transformations[0]["type"].get<std::string>();
+        EXPECT(type == "scale", "Expected type to be 'scale', but got '", type, "'");
+        
+        const auto scale = coordinate_transformations[0]["scale"];
+        EXPECT_EQ(size_t, scale.size(), 5);
+        
+        // Level 0 should have scale 1 for all dimensions
+        if (level == 0) {
+            for (int i = 0; i < 5; i++) {
+                EXPECT_EQ(double, scale[i].get<double>(), 1.0);
+            }
+        } else {
+            fs::path array_metadata_path = fs::path(test_path) / std::to_string(level) / "zarr.json";
+            std::ifstream af = std::ifstream(array_metadata_path);
+            nlohmann::json array_metadata = nlohmann::json::parse(af);
+            
+            const auto& shape = array_metadata["shape"];
+            
+            // Calculate and verify the expected scale factors
+            // t and c dimensions should still be 1.0
+            EXPECT_EQ(double, scale[0].get<double>(), 1.0); // t dimension
+            EXPECT_EQ(double, scale[1].get<double>(), 1.0); // c dimension
+            
+            // z dimension should be 1.0 since we have only 1 plane
+            EXPECT_EQ(double, scale[2].get<double>(), 1.0);
+            
+            // y and x dimensions should match the ratio of original size to downsampled size
+            double expected_y_scale = static_cast<double>(array_height) / shape[3].get<int>();
+            double expected_x_scale = static_cast<double>(array_width) / shape[4].get<int>();
+
+            EXPECT(std::abs(scale[3].get<double>() - expected_y_scale) < 0.01,
+                   "For level ", level, ", expected y scale to be around ", expected_y_scale,
+                   ", but got ", scale[3].get<double>());
+                   
+            EXPECT(std::abs(scale[4].get<double>() - expected_x_scale) < 0.01,
+                   "For level ", level, ", expected x scale to be around ", expected_x_scale,
+                   ", but got ", scale[4].get<double>());
+
+            // Verify that we're not doing 3D downsampling (z scale should be 1.0)
+            EXPECT_EQ(double, scale[2].get<double>(), 1.0);
+        }
+    }
+}
+
+int
+main()
+{
+    Zarr_set_log_level(ZarrLogLevel_Debug);
+
+    auto* stream = setup();
+    std::vector<uint16_t> frame(array_width * array_height, 0);
+
+    int retval = 1;
+
+    try {
+        size_t bytes_out;
+        for (auto i = 0; i < frames_to_acquire; ++i) {
+            ZarrStatusCode status = ZarrStream_append(
+              stream, frame.data(), bytes_of_frame, &bytes_out);
+            EXPECT(status == ZarrStatusCode_Success,
+                   "Failed to append frame ", i, ": ",
+                   Zarr_get_status_message(status));
+            EXPECT_EQ(size_t, bytes_out, bytes_of_frame);
+        }
+
+        ZarrStream_destroy(stream);
+
+        // Verify the multiscale metadata reflects our expectations
+        verify_multiscale_metadata();
+
+        // Clean up
+        fs::remove_all(test_path);
+
+        retval = 0;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Caught exception: ", e.what());
+    }
+
+    return retval;
+}


### PR DESCRIPTION
This PR addresses two issues in the multiscale downsampling implementation:

1. Fixed 3D downsampling detection to only apply when the third spatial dimension is
   actually non-trivial (more than 1 element). Previously, we would attempt 3D downsampling
   even for essentially 2-spatial-D datasets that had a spatial Z dimension with only one plane.

2. Revised the multiscale coordinate transform calculation to use actual dimension ratios
   instead of fixed power-of-2 scaling factors. This ensures that the OME-NGFF metadata
   accurately reflects the true relationship between resolution levels for all dimensions.