### PR TITLE
Add dimension unit and scale support; add `dimension_names`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- API supports `unit` (string) and `scale` (double) properties to C `ZarrDimensionProperties` struct and Python
+  `DimensionProperties` class
+    - Validation ensures scale values are nonnegative (scale values of 0 default to 1)
+- Support for optional Zarr V3 `dimension_names` field in array metadata
+
+### Changed
+
+- Modified OME metadata generation to write unit and scale information
+
+### Removed
+
+- Remove hardcoded "micrometer" unit values from x and y dimensions
+
 ## [0.3.1] - [2025-04-22](https://github.com/acquire-project/acquire-zarr/compare/v0.3.0...v0.3.1)
 
 ### Fixed

--- a/include/zarr.types.h
+++ b/include/zarr.types.h
@@ -111,14 +111,16 @@ extern "C"
      */
     typedef struct
     {
-        const char* name;       /**< Name of the dimension */
-        ZarrDimensionType type; /**< Type of the dimension */
-        uint32_t array_size_px; /**< Size of the array along this dimension in
-                                       pixels */
-        uint32_t chunk_size_px; /**< Size of the chunks along this dimension in
-                                       pixels */
+        const char* name;           /**< Name of the dimension */
+        ZarrDimensionType type;     /**< Type of the dimension */
+        uint32_t array_size_px;     /**< Size of the array along this dimension
+                                         in pixels */
+        uint32_t chunk_size_px;     /**< Size of the chunks along this dimension
+                                         in pixels */
         uint32_t shard_size_chunks; /**< Number of chunks in a shard along this
-                                       dimension */
+                                         dimension */
+        const char* unit;           /** Unit of the dimension */
+        double scale;               /**< Scale of the dimension */
     } ZarrDimensionProperties;
 
 #ifdef __cplusplus

--- a/python/acquire_zarr/__init__.pyi
+++ b/python/acquire_zarr/__init__.pyi
@@ -158,7 +158,9 @@ class Dimension:
     chunk_size_px: int
     kind: DimensionType
     name: str
+    scale: float
     shard_size_chunks: int
+    unit: Optional[str]
 
     def __init__(self, **kwargs) -> None: ...
     def __repr__(self) -> str: ...

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -69,6 +69,8 @@ def test_set_dimensions(settings):
         acquire_zarr.Dimension(
             name="foo",
             kind=acquire_zarr.DimensionType.TIME,
+            unit="nanosecond",
+            scale=2.71828,
             array_size_px=1,
             chunk_size_px=2,
             shard_size_chunks=3,
@@ -76,6 +78,7 @@ def test_set_dimensions(settings):
         acquire_zarr.Dimension(
             name="bar",
             kind=acquire_zarr.DimensionType.SPACE,
+            unit="micrometer",
             array_size_px=4,
             chunk_size_px=5,
             shard_size_chunks=6,
@@ -93,18 +96,24 @@ def test_set_dimensions(settings):
 
     assert settings.dimensions[0].name == "foo"
     assert settings.dimensions[0].kind == acquire_zarr.DimensionType.TIME
+    assert settings.dimensions[0].unit == "nanosecond"
+    assert settings.dimensions[0].scale == 2.71828
     assert settings.dimensions[0].array_size_px == 1
     assert settings.dimensions[0].chunk_size_px == 2
     assert settings.dimensions[0].shard_size_chunks == 3
 
     assert settings.dimensions[1].name == "bar"
     assert settings.dimensions[1].kind == acquire_zarr.DimensionType.SPACE
+    assert settings.dimensions[1].unit == "micrometer"
+    assert settings.dimensions[1].scale == 1.0
     assert settings.dimensions[1].array_size_px == 4
     assert settings.dimensions[1].chunk_size_px == 5
     assert settings.dimensions[1].shard_size_chunks == 6
 
     assert settings.dimensions[2].name == "baz"
     assert settings.dimensions[2].kind == acquire_zarr.DimensionType.OTHER
+    assert settings.dimensions[2].unit is None
+    assert settings.dimensions[2].scale == 1.0
     assert settings.dimensions[2].array_size_px == 7
     assert settings.dimensions[2].chunk_size_px == 8
     assert settings.dimensions[2].shard_size_chunks == 9

--- a/src/streaming/zarr.dimension.hh
+++ b/src/streaming/zarr.dimension.hh
@@ -3,6 +3,7 @@
 #include "zarr.types.h"
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -15,17 +16,26 @@ struct ZarrDimension
                   ZarrDimensionType type,
                   uint32_t array_size_px,
                   uint32_t chunk_size_px,
-                  uint32_t shard_size_chunks)
+                  uint32_t shard_size_chunks,
+                  std::string_view unit = "",
+                  double scale = 1.0)
       : name(name)
       , type(type)
       , array_size_px(array_size_px)
       , chunk_size_px(chunk_size_px)
       , shard_size_chunks(shard_size_chunks)
+      , scale(scale)
     {
+        if (!unit.empty()) {
+            this->unit = unit;
+        }
     }
 
     std::string name;
     ZarrDimensionType type{ ZarrDimensionType_Space };
+
+    std::optional<std::string> unit;
+    double scale{ 1.0 };
 
     uint32_t array_size_px{ 0 };
     uint32_t chunk_size_px{ 0 };

--- a/src/streaming/zarrv3.array.writer.cpp
+++ b/src/streaming/zarrv3.array.writer.cpp
@@ -500,6 +500,12 @@ zarr::ZarrV3ArrayWriter::write_array_metadata_()
     metadata["data_type"] = sample_type_to_dtype(config_.dtype);
     metadata["storage_transformers"] = json::array();
 
+    std::vector<std::string> dimension_names(dims->ndims());
+    for (auto i = 0; i < dimension_names.size(); ++i) {
+        dimension_names[i] = dims->at(i).name;
+    }
+    metadata["dimension_names"] = dimension_names;
+
     auto codecs = json::array();
 
     auto sharding_indexed = json::object();

--- a/tests/integration/stream-zarr-v2-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v2-compressed-to-filesystem.cpp
@@ -59,19 +59,49 @@ setup()
 
     ZarrDimensionProperties* dim;
     dim = settings.dimensions;
-    *dim = DIM("t", ZarrDimensionType_Time, array_timepoints, chunk_timepoints, 0);
+    *dim = DIM("t",
+               ZarrDimensionType_Time,
+               array_timepoints,
+               chunk_timepoints,
+               0,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
-    *dim = DIM("c", ZarrDimensionType_Channel, array_channels, chunk_channels, 0);
+    *dim = DIM("c",
+               ZarrDimensionType_Channel,
+               array_channels,
+               chunk_channels,
+               0,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM("z", ZarrDimensionType_Space, array_planes, chunk_planes, 0);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               0,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM("y", ZarrDimensionType_Space, array_height, chunk_height, 0);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               0,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim = DIM("x", ZarrDimensionType_Space, array_width, chunk_width, 0);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               0,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -91,36 +121,57 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
     EXPECT(
       type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
+    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();
@@ -137,9 +188,9 @@ verify_base_metadata(const nlohmann::json& meta)
     EXPECT_EQ(size_t, scale.size(), 5);
     EXPECT_EQ(double, scale[0].get<double>(), 1.0);
     EXPECT_EQ(double, scale[1].get<double>(), 1.0);
-    EXPECT_EQ(double, scale[2].get<double>(), 1.0);
-    EXPECT_EQ(double, scale[3].get<double>(), 1.0);
-    EXPECT_EQ(double, scale[4].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[2].get<double>(), 1.4);
+    EXPECT_EQ(double, scale[3].get<double>(), 0.9);
+    EXPECT_EQ(double, scale[4].get<double>(), 0.9);
 }
 
 void

--- a/tests/integration/stream-zarr-v2-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v2-compressed-to-filesystem.cpp
@@ -91,7 +91,7 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -112,25 +112,15 @@ verify_base_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();

--- a/tests/integration/stream-zarr-v2-compressed-to-s3.cpp
+++ b/tests/integration/stream-zarr-v2-compressed-to-s3.cpp
@@ -222,7 +222,7 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -243,25 +243,15 @@ verify_base_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();

--- a/tests/integration/stream-zarr-v2-compressed-to-s3.cpp
+++ b/tests/integration/stream-zarr-v2-compressed-to-s3.cpp
@@ -188,21 +188,49 @@ setup()
 
     ZarrDimensionProperties* dim;
     dim = settings.dimensions;
-    *dim =
-      DIM("t", ZarrDimensionType_Time, array_timepoints, chunk_timepoints, 0);
+    *dim = DIM("t",
+               ZarrDimensionType_Time,
+               array_timepoints,
+               chunk_timepoints,
+               0,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
-    *dim =
-      DIM("c", ZarrDimensionType_Channel, array_channels, chunk_channels, 0);
+    *dim = DIM("c",
+               ZarrDimensionType_Channel,
+               array_channels,
+               chunk_channels,
+               0,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM("z", ZarrDimensionType_Space, array_planes, chunk_planes, 0);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               0,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM("y", ZarrDimensionType_Space, array_height, chunk_height, 0);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               0,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim = DIM("x", ZarrDimensionType_Space, array_width, chunk_width, 0);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               0,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -222,36 +250,57 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
     EXPECT(
       type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
+    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();
@@ -266,11 +315,11 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto scale = coordinate_transformations["scale"];
     EXPECT_EQ(size_t, scale.size(), 5);
-    EXPECT_EQ(int, scale[0].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[2].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[3].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[4].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[0].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[1].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[2].get<double>(), 1.4);
+    EXPECT_EQ(double, scale[3].get<double>(), 0.9);
+    EXPECT_EQ(double, scale[4].get<double>(), 0.9);
 }
 
 void

--- a/tests/integration/stream-zarr-v2-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v2-raw-to-filesystem.cpp
@@ -52,19 +52,49 @@ setup()
 
     ZarrDimensionProperties* dim;
     dim = settings.dimensions;
-    *dim = DIM("t", ZarrDimensionType_Time, array_timepoints, chunk_timepoints, 0);
+    *dim = DIM("t",
+               ZarrDimensionType_Time,
+               array_timepoints,
+               chunk_timepoints,
+               0,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
-    *dim = DIM("c", ZarrDimensionType_Channel, array_channels, chunk_channels, 0);
+    *dim = DIM("c",
+               ZarrDimensionType_Channel,
+               array_channels,
+               chunk_channels,
+               0,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM("z", ZarrDimensionType_Space, array_planes, chunk_planes, 0);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               0,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM("y", ZarrDimensionType_Space, array_height, chunk_height, 0);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               0,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim = DIM("x", ZarrDimensionType_Space, array_width, chunk_width, 0);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               0,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -84,32 +114,57 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
-    EXPECT(type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(
+      type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
-    EXPECT(type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
-    EXPECT(type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
+    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
-    EXPECT(type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();
@@ -123,11 +178,11 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto scale = coordinate_transformations["scale"];
     EXPECT_EQ(size_t, scale.size(), 5);
-    EXPECT_EQ(int, scale[0].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[2].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[3].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[4].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[0].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[1].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[2].get<double>(), 1.4);
+    EXPECT_EQ(double, scale[3].get<double>(), 0.9);
+    EXPECT_EQ(double, scale[4].get<double>(), 0.9);
 }
 
 void

--- a/tests/integration/stream-zarr-v2-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v2-raw-to-filesystem.cpp
@@ -84,7 +84,7 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -103,23 +103,13 @@ verify_base_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();

--- a/tests/integration/stream-zarr-v2-raw-to-s3.cpp
+++ b/tests/integration/stream-zarr-v2-raw-to-s3.cpp
@@ -215,7 +215,7 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -239,25 +239,17 @@ verify_base_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '%s'", name.c_str());
     EXPECT(type == "space",
            "Expected type to be 'space', but got '%s'",
            type.c_str());
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '%s'",
-           unit.c_str());
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '%s'", name.c_str());
     EXPECT(type == "space",
            "Expected type to be 'space', but got '%s'",
            type.c_str());
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '%s'",
-           unit.c_str());
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();

--- a/tests/integration/stream-zarr-v2-raw-to-s3.cpp
+++ b/tests/integration/stream-zarr-v2-raw-to-s3.cpp
@@ -181,21 +181,49 @@ setup()
 
     ZarrDimensionProperties* dim;
     dim = settings.dimensions;
-    *dim =
-      DIM("t", ZarrDimensionType_Time, array_timepoints, chunk_timepoints, 0);
+    *dim = DIM("t",
+               ZarrDimensionType_Time,
+               array_timepoints,
+               chunk_timepoints,
+               0,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
-    *dim =
-      DIM("c", ZarrDimensionType_Channel, array_channels, chunk_channels, 0);
+    *dim = DIM("c",
+               ZarrDimensionType_Channel,
+               array_channels,
+               chunk_channels,
+               0,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM("z", ZarrDimensionType_Space, array_planes, chunk_planes, 0);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               0,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM("y", ZarrDimensionType_Space, array_height, chunk_height, 0);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               0,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim = DIM("x", ZarrDimensionType_Space, array_width, chunk_width, 0);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               0,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -215,41 +243,57 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
-    EXPECT(name == "t", "Expected name to be 't', but got '%s'", name.c_str());
-    EXPECT(
-      type == "time", "Expected type to be 'time', but got '%s'", type.c_str());
+    EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
+    EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
-    EXPECT(name == "c", "Expected name to be 'c', but got '%s'", name.c_str());
-    EXPECT(type == "channel",
-           "Expected type to be 'channel', but got '%s'",
-           type.c_str());
+    EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
+    EXPECT(
+      type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
-    EXPECT(name == "z", "Expected name to be 'z', but got '%s'", name.c_str());
-    EXPECT(type == "space",
-           "Expected type to be 'space', but got '%s'",
-           type.c_str());
+    unit = axes[2]["unit"];
+    EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    EXPECT(name == "y", "Expected name to be 'y', but got '%s'", name.c_str());
-    EXPECT(type == "space",
-           "Expected type to be 'space', but got '%s'",
-           type.c_str());
+    unit = axes[3]["unit"];
+    EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    EXPECT(name == "x", "Expected name to be 'x', but got '%s'", name.c_str());
-    EXPECT(type == "space",
-           "Expected type to be 'space', but got '%s'",
-           type.c_str());
+    unit = axes[4]["unit"];
+    EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
+    EXPECT(
+      type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();
@@ -265,11 +309,11 @@ verify_base_metadata(const nlohmann::json& meta)
 
     const auto scale = coordinate_transformations["scale"];
     EXPECT_EQ(size_t, scale.size(), 5);
-    EXPECT_EQ(int, scale[0].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[2].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[3].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[4].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[0].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[1].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[2].get<double>(), 1.4);
+    EXPECT_EQ(double, scale[3].get<double>(), 0.9);
+    EXPECT_EQ(double, scale[4].get<double>(), 0.9);
 }
 
 void

--- a/tests/integration/stream-zarr-v3-2d-multiscale-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-2d-multiscale-to-filesystem.cpp
@@ -75,22 +75,36 @@ setup()
                ZarrDimensionType_Time,
                array_timepoints,
                chunk_timepoints,
-               shard_timepoints);
+               shard_timepoints,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
     *dim = DIM("c",
                ZarrDimensionType_Channel,
                array_channels,
                chunk_channels,
-               shard_channels);
+               shard_channels,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM(
-      "y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               shard_height,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 3;
-    *dim =
-      DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               shard_width,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -122,30 +136,46 @@ verify_group_metadata(const nlohmann::json& meta)
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 4); // Now 4 axes
 
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
     EXPECT(
       type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"];
     for (auto level = 0; level < 3; ++level) {
@@ -168,10 +198,10 @@ verify_group_metadata(const nlohmann::json& meta)
 
         const auto scale = coordinate_transformations[0]["scale"];
         EXPECT_EQ(size_t, scale.size(), 4); // Now 4 scale factors
-        EXPECT_EQ(int, scale[0].get<double>(), 1.0);
-        EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-        EXPECT_EQ(int, scale[2].get<double>(), std::pow(2, level));
-        EXPECT_EQ(int, scale[3].get<double>(), std::pow(2, level));
+        EXPECT_EQ(double, scale[0].get<double>(), 1.0);
+        EXPECT_EQ(double, scale[1].get<double>(), 1.0);
+        EXPECT_EQ(double, scale[2].get<double>(), std::pow(2, level) * 0.9);
+        EXPECT_EQ(double, scale[3].get<double>(), std::pow(2, level) * 0.9);
     }
 }
 

--- a/tests/integration/stream-zarr-v3-2d-multiscale-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-2d-multiscale-to-filesystem.cpp
@@ -122,7 +122,7 @@ verify_group_metadata(const nlohmann::json& meta)
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 4); // Now 4 axes
 
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -137,25 +137,15 @@ verify_group_metadata(const nlohmann::json& meta)
 
     name = axes[2]["name"];
     type = axes[2]["type"];
-    unit = axes[2]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"];
     for (auto level = 0; level < 3; ++level) {

--- a/tests/integration/stream-zarr-v3-3d-multiscale-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-3d-multiscale-to-filesystem.cpp
@@ -130,7 +130,7 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -151,25 +151,15 @@ verify_group_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"];
     for (auto level = 0; level < 3; ++level) {

--- a/tests/integration/stream-zarr-v3-3d-multiscale-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-3d-multiscale-to-filesystem.cpp
@@ -80,26 +80,45 @@ setup()
                ZarrDimensionType_Time,
                array_timepoints,
                chunk_timepoints,
-               shard_timepoints);
+               shard_timepoints,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
     *dim = DIM("c",
                ZarrDimensionType_Channel,
                array_channels,
                chunk_channels,
-               shard_channels);
+               shard_channels,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM(
-      "z", ZarrDimensionType_Space, array_planes, chunk_planes, shard_planes);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               shard_planes,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM(
-      "y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               shard_height,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim =
-      DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               shard_width,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -130,36 +149,57 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
     EXPECT(
       type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
+    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"];
     for (auto level = 0; level < 3; ++level) {
@@ -184,9 +224,9 @@ verify_group_metadata(const nlohmann::json& meta)
         EXPECT_EQ(size_t, scale.size(), 5);
         EXPECT_EQ(int, scale[0].get<double>(), 1.0);
         EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-        EXPECT_EQ(int, scale[2].get<double>(), std::pow(2, level));
-        EXPECT_EQ(int, scale[3].get<double>(), std::pow(2, level));
-        EXPECT_EQ(int, scale[4].get<double>(), std::pow(2, level));
+        EXPECT_EQ(int, scale[2].get<double>(), std::pow(2, level) * 1.4);
+        EXPECT_EQ(int, scale[3].get<double>(), std::pow(2, level) * 0.9);
+        EXPECT_EQ(int, scale[4].get<double>(), std::pow(2, level) * 0.9);
     }
 }
 

--- a/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
@@ -73,21 +73,50 @@ setup()
 
     CHECK_OK(ZarrStreamSettings_create_dimension_array(&settings, 5));
 
-    ZarrDimensionProperties* dim;
-    dim = settings.dimensions;
-    *dim = DIM("t", ZarrDimensionType_Time, array_timepoints, chunk_timepoints, shard_timepoints);
+    ZarrDimensionProperties* dim = settings.dimensions;
+    *dim = DIM("t",
+               ZarrDimensionType_Time,
+               array_timepoints,
+               chunk_timepoints,
+               shard_timepoints,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
-    *dim = DIM("c", ZarrDimensionType_Channel, array_channels, chunk_channels, shard_channels);
+    *dim = DIM("c",
+               ZarrDimensionType_Channel,
+               array_channels,
+               chunk_channels,
+               shard_channels,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM("z", ZarrDimensionType_Space, array_planes, chunk_planes, shard_planes);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               shard_planes,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM("y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               shard_height,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim = DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               shard_width,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -118,36 +147,57 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
     EXPECT(
       type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
+    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();
@@ -162,11 +212,11 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto scale = coordinate_transformations["scale"];
     EXPECT_EQ(size_t, scale.size(), 5);
-    EXPECT_EQ(int, scale[0].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[2].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[3].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[4].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[0].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[1].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[2].get<double>(), 1.4);
+    EXPECT_EQ(double, scale[3].get<double>(), 0.9);
+    EXPECT_EQ(double, scale[4].get<double>(), 0.9);
 }
 
 void
@@ -229,6 +279,25 @@ verify_array_metadata(const nlohmann::json& meta)
            "Expected shuffle to be 'bitshuffle', got ",
            blosc_config["shuffle"].get<std::string>());
     EXPECT_EQ(int, blosc_config["typesize"].get<int>(), 2);
+
+    const auto& dimension_names = meta["dimension_names"];
+    EXPECT_EQ(size_t, dimension_names.size(), 5);
+
+    EXPECT(dimension_names[0].get<std::string>() == "t",
+           "Expected first dimension name to be 't', got ",
+           dimension_names[0].get<std::string>());
+    EXPECT(dimension_names[1].get<std::string>() == "c",
+           "Expected second dimension name to be 'c', got ",
+           dimension_names[1].get<std::string>());
+    EXPECT(dimension_names[2].get<std::string>() == "z",
+           "Expected third dimension name to be 'z', got ",
+           dimension_names[2].get<std::string>());
+    EXPECT(dimension_names[3].get<std::string>() == "y",
+           "Expected fourth dimension name to be 'y', got ",
+           dimension_names[3].get<std::string>());
+    EXPECT(dimension_names[4].get<std::string>() == "x",
+           "Expected fifth dimension name to be 'x', got ",
+           dimension_names[4].get<std::string>());
 }
 
 void

--- a/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-filesystem.cpp
@@ -118,7 +118,7 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -139,25 +139,15 @@ verify_group_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();

--- a/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
@@ -207,26 +207,45 @@ setup()
                ZarrDimensionType_Time,
                array_timepoints,
                chunk_timepoints,
-               shard_timepoints);
+               shard_timepoints,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
     *dim = DIM("c",
                ZarrDimensionType_Channel,
                array_channels,
                chunk_channels,
-               shard_channels);
+               shard_channels,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM(
-      "z", ZarrDimensionType_Space, array_planes, chunk_planes, shard_planes);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               shard_planes,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM(
-      "y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               shard_height,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim =
-      DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               shard_width,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -257,36 +276,57 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
     EXPECT(
       type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
+    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();
@@ -301,11 +341,11 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto scale = coordinate_transformations["scale"];
     EXPECT_EQ(size_t, scale.size(), 5);
-    EXPECT_EQ(int, scale[0].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[2].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[3].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[4].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[0].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[1].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[2].get<double>(), 1.4);
+    EXPECT_EQ(double, scale[3].get<double>(), 0.9);
+    EXPECT_EQ(double, scale[4].get<double>(), 0.9);
 }
 
 void
@@ -368,6 +408,25 @@ verify_array_metadata(const nlohmann::json& meta)
            "Expected shuffle to be 'shuffle', got ",
            blosc_config["shuffle"].get<std::string>());
     EXPECT_EQ(int, blosc_config["typesize"].get<int>(), 2);
+
+    const auto& dimension_names = meta["dimension_names"];
+    EXPECT_EQ(size_t, dimension_names.size(), 5);
+
+    EXPECT(dimension_names[0].get<std::string>() == "t",
+           "Expected first dimension name to be 't', got ",
+           dimension_names[0].get<std::string>());
+    EXPECT(dimension_names[1].get<std::string>() == "c",
+           "Expected second dimension name to be 'c', got ",
+           dimension_names[1].get<std::string>());
+    EXPECT(dimension_names[2].get<std::string>() == "z",
+           "Expected third dimension name to be 'z', got ",
+           dimension_names[2].get<std::string>());
+    EXPECT(dimension_names[3].get<std::string>() == "y",
+           "Expected fourth dimension name to be 'y', got ",
+           dimension_names[3].get<std::string>());
+    EXPECT(dimension_names[4].get<std::string>() == "x",
+           "Expected fifth dimension name to be 'x', got ",
+           dimension_names[4].get<std::string>());
 }
 
 void

--- a/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-compressed-to-s3.cpp
@@ -257,7 +257,7 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -278,25 +278,15 @@ verify_group_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();

--- a/tests/integration/stream-zarr-v3-multi-frame-append.cpp
+++ b/tests/integration/stream-zarr-v3-multi-frame-append.cpp
@@ -13,7 +13,7 @@ static const size_t frames_to_acquire = 12;
 static const size_t frames_per_append = 3;
 static const fs::path test_path = "multi-frame-test.zarr";
 
-static ZarrStream* 
+static ZarrStream*
 setup() {
     const auto test_path_str = test_path.string();
     const auto test_path_cstr = test_path_str.c_str();

--- a/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
@@ -122,7 +122,7 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -143,25 +143,15 @@ verify_group_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();

--- a/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-filesystem.cpp
@@ -72,26 +72,45 @@ setup()
                ZarrDimensionType_Time,
                array_timepoints,
                chunk_timepoints,
-               shard_timepoints);
+               shard_timepoints,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
     *dim = DIM("c",
                ZarrDimensionType_Channel,
                array_channels,
                chunk_channels,
-               shard_channels);
+               shard_channels,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM(
-      "z", ZarrDimensionType_Space, array_planes, chunk_planes, shard_planes);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               shard_planes,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM(
-      "y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               shard_height,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim =
-      DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               shard_width,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -122,36 +141,57 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
     EXPECT(
       type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
+    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();
@@ -168,9 +208,9 @@ verify_group_metadata(const nlohmann::json& meta)
     EXPECT_EQ(size_t, scale.size(), 5);
     EXPECT_EQ(int, scale[0].get<double>(), 1.0);
     EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[2].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[3].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[4].get<double>(), 1.0);
+    EXPECT_EQ(int, scale[2].get<double>(), 1.4);
+    EXPECT_EQ(int, scale[3].get<double>(), 0.9);
+    EXPECT_EQ(int, scale[4].get<double>(), 0.9);
 }
 
 void
@@ -218,6 +258,25 @@ verify_array_metadata(const nlohmann::json& meta)
     EXPECT(internal_codecs[0]["name"].get<std::string>() == "bytes",
            "Expected first codec to be 'bytes', got ",
            internal_codecs[0]["name"].get<std::string>());
+
+    const auto& dimension_names = meta["dimension_names"];
+    EXPECT_EQ(size_t, dimension_names.size(), 5);
+
+    EXPECT(dimension_names[0].get<std::string>() == "t",
+           "Expected first dimension name to be 't', got ",
+           dimension_names[0].get<std::string>());
+    EXPECT(dimension_names[1].get<std::string>() == "c",
+           "Expected second dimension name to be 'c', got ",
+           dimension_names[1].get<std::string>());
+    EXPECT(dimension_names[2].get<std::string>() == "z",
+           "Expected third dimension name to be 'z', got ",
+           dimension_names[2].get<std::string>());
+    EXPECT(dimension_names[3].get<std::string>() == "y",
+           "Expected fourth dimension name to be 'y', got ",
+           dimension_names[3].get<std::string>());
+    EXPECT(dimension_names[4].get<std::string>() == "x",
+           "Expected fifth dimension name to be 'x', got ",
+           dimension_names[4].get<std::string>());
 }
 
 void

--- a/tests/integration/stream-zarr-v3-raw-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-s3.cpp
@@ -198,19 +198,49 @@ setup()
 
     ZarrDimensionProperties* dim;
     dim = settings.dimensions;
-    *dim = DIM("t", ZarrDimensionType_Time, array_timepoints, chunk_timepoints, shard_timepoints);
+    *dim = DIM("t",
+               ZarrDimensionType_Time,
+               array_timepoints,
+               chunk_timepoints,
+               shard_timepoints,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 1;
-    *dim = DIM("c", ZarrDimensionType_Channel, array_channels, chunk_channels, shard_channels);
+    *dim = DIM("c",
+               ZarrDimensionType_Channel,
+               array_channels,
+               chunk_channels,
+               shard_channels,
+               nullptr,
+               1.0);
 
     dim = settings.dimensions + 2;
-    *dim = DIM("z", ZarrDimensionType_Space, array_planes, chunk_planes, shard_planes);
+    *dim = DIM("z",
+               ZarrDimensionType_Space,
+               array_planes,
+               chunk_planes,
+               shard_planes,
+               "millimeter",
+               1.4);
 
     dim = settings.dimensions + 3;
-    *dim = DIM("y", ZarrDimensionType_Space, array_height, chunk_height, shard_height);
+    *dim = DIM("y",
+               ZarrDimensionType_Space,
+               array_height,
+               chunk_height,
+               shard_height,
+               "micrometer",
+               0.9);
 
     dim = settings.dimensions + 4;
-    *dim = DIM("x", ZarrDimensionType_Space, array_width, chunk_width, shard_width);
+    *dim = DIM("x",
+               ZarrDimensionType_Space,
+               array_width,
+               chunk_width,
+               shard_width,
+               "micrometer",
+               0.9);
 
     auto* stream = ZarrStream_create(&settings);
     ZarrStreamSettings_destroy_dimension_array(&settings);
@@ -241,36 +271,57 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type;
+    std::string name, type, unit;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
     EXPECT(name == "t", "Expected name to be 't', but got '", name, "'");
     EXPECT(type == "time", "Expected type to be 'time', but got '", type, "'");
+    EXPECT(!axes[0].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[0]["unit"].get<std::string>());
 
     name = axes[1]["name"];
     type = axes[1]["type"];
     EXPECT(name == "c", "Expected name to be 'c', but got '", name, "'");
     EXPECT(
       type == "channel", "Expected type to be 'channel', but got '", type, "'");
+    EXPECT(!axes[1].contains("unit"),
+           "Expected unit to be missing, got ",
+           axes[1]["unit"].get<std::string>());
 
     name = axes[2]["name"];
     type = axes[2]["type"];
+    unit = axes[2]["unit"];
     EXPECT(name == "z", "Expected name to be 'z', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "millimeter",
+           "Expected unit to be 'millimeter', but got '",
+           unit,
+           "'");
 
     name = axes[3]["name"];
     type = axes[3]["type"];
+    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
+    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
+    EXPECT(unit == "micrometer",
+           "Expected unit to be 'micrometer', but got '",
+           unit,
+           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();
@@ -285,11 +336,11 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto scale = coordinate_transformations["scale"];
     EXPECT_EQ(size_t, scale.size(), 5);
-    EXPECT_EQ(int, scale[0].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[1].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[2].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[3].get<double>(), 1.0);
-    EXPECT_EQ(int, scale[4].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[0].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[1].get<double>(), 1.0);
+    EXPECT_EQ(double, scale[2].get<double>(), 1.4);
+    EXPECT_EQ(double, scale[3].get<double>(), 0.9);
+    EXPECT_EQ(double, scale[4].get<double>(), 0.9);
 }
 
 void
@@ -337,6 +388,25 @@ verify_array_metadata(const nlohmann::json& meta)
     EXPECT(internal_codecs[0]["name"].get<std::string>() == "bytes",
            "Expected first codec to be 'bytes', got ",
            internal_codecs[0]["name"].get<std::string>());
+
+    const auto& dimension_names = meta["dimension_names"];
+    EXPECT_EQ(size_t, dimension_names.size(), 5);
+
+    EXPECT(dimension_names[0].get<std::string>() == "t",
+           "Expected first dimension name to be 't', got ",
+           dimension_names[0].get<std::string>());
+    EXPECT(dimension_names[1].get<std::string>() == "c",
+           "Expected second dimension name to be 'c', got ",
+           dimension_names[1].get<std::string>());
+    EXPECT(dimension_names[2].get<std::string>() == "z",
+           "Expected third dimension name to be 'z', got ",
+           dimension_names[2].get<std::string>());
+    EXPECT(dimension_names[3].get<std::string>() == "y",
+           "Expected fourth dimension name to be 'y', got ",
+           dimension_names[3].get<std::string>());
+    EXPECT(dimension_names[4].get<std::string>() == "x",
+           "Expected fifth dimension name to be 'x', got ",
+           dimension_names[4].get<std::string>());
 }
 
 void

--- a/tests/integration/stream-zarr-v3-raw-to-s3.cpp
+++ b/tests/integration/stream-zarr-v3-raw-to-s3.cpp
@@ -241,7 +241,7 @@ verify_group_metadata(const nlohmann::json& meta)
 
     const auto axes = multiscales["axes"];
     EXPECT_EQ(size_t, axes.size(), 5);
-    std::string name, type, unit;
+    std::string name, type;
 
     name = axes[0]["name"];
     type = axes[0]["type"];
@@ -262,25 +262,15 @@ verify_group_metadata(const nlohmann::json& meta)
 
     name = axes[3]["name"];
     type = axes[3]["type"];
-    unit = axes[3]["unit"];
     EXPECT(name == "y", "Expected name to be 'y', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     name = axes[4]["name"];
     type = axes[4]["type"];
-    unit = axes[4]["unit"];
     EXPECT(name == "x", "Expected name to be 'x', but got '", name, "'");
     EXPECT(
       type == "space", "Expected type to be 'space', but got '", type, "'");
-    EXPECT(unit == "micrometer",
-           "Expected unit to be 'micrometer', but got '",
-           unit,
-           "'");
 
     const auto datasets = multiscales["datasets"][0];
     const std::string path = datasets["path"].get<std::string>();

--- a/tests/integration/test.macros.hh
+++ b/tests/integration/test.macros.hh
@@ -50,9 +50,13 @@
     } while (0)
 
 #define SIZED(str) str, sizeof(str)
-#define DIM(name_, type_, array_size, chunk_size, shard_size)                  \
+#define DIM(name_, type_, array_size, chunk_size, shard_size, unit_, scale_)   \
     {                                                                          \
-        .name = (name_), .type = (type_),          \
-        .array_size_px = (array_size), .chunk_size_px = (chunk_size),              \
-        .shard_size_chunks = (shard_size)                                        \
+        .name = (name_),                                                       \
+        .type = (type_),                                                       \
+        .array_size_px = (array_size),                                         \
+        .chunk_size_px = (chunk_size),                                         \
+        .shard_size_chunks = (shard_size),                                     \
+        .unit = (unit_),                                                       \
+        .scale = (scale_),                                                     \
     }


### PR DESCRIPTION
This PR adds support for specifying physical units and scale factors for dimensions in Zarr metadata. Other coordinate transformations are not supported.

Also adds support for optional `dimension_names` [field](https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html#dimension-names) in array metadata (Zarr V3 only).

Tests have been updated to ensure unit and scale values are written as expected.

### Added
- API supports `unit` (string) and `scale` (double) properties to C `ZarrDimensionProperties` struct and Python `DimensionProperties` class
    - Validation ensures scale values are nonnegative (scale values of 0 default to 1)
- Support for optional Zarr V3 `dimension_names` field in array metadata

### Changed
- Modified OME metadata generation to write unit and scale information

### Removed
- Remove hardcoded "micrometer" unit values from x and y dimensions