### PR TITLE
Expose method used to downsample arrays

### DIFF
--- a/include/acquire.zarr.h
+++ b/include/acquire.zarr.h
@@ -33,6 +33,7 @@ extern "C"
         ZarrDataType data_type; /**< The pixel data type of the dataset. */
         ZarrVersion version; /**< The version of the Zarr format to use. 2 or 3. */
         unsigned int max_threads; /**< The maximum number of threads to use in the stream. Set to 0 to use the supported number of concurrent threads. */
+        ZarrDownsamplingMethod downsampling_method; /**< The downsampling method to use for multiscale streaming. */
     } ZarrStreamSettings;
 
     typedef struct ZarrStream_s ZarrStream;

--- a/include/zarr.types.h
+++ b/include/zarr.types.h
@@ -82,6 +82,15 @@ extern "C"
         ZarrDimensionTypeCount
     } ZarrDimensionType;
 
+    typedef enum
+    {
+        ZarrDownsamplingMethod_None = 0,
+        ZarrDownsamplingMethod_Mean,
+        ZarrDownsamplingMethod_Min,
+        ZarrDownsamplingMethod_Max,
+        ZarrDownsamplingMethodCount,
+    } ZarrDownsamplingMethod;
+
     /**
      * @brief S3 settings for streaming to Zarr.
      */

--- a/src/streaming/downsampler.hh
+++ b/src/streaming/downsampler.hh
@@ -10,7 +10,7 @@ namespace zarr {
 class Downsampler
 {
   public:
-    explicit Downsampler(const ArrayWriterConfig& config);
+    Downsampler(const ArrayWriterConfig& config, ZarrDownsamplingMethod method);
 
     /**
      * @brief Add a full-resolution frame to the downsampler.
@@ -35,8 +35,15 @@ class Downsampler
     writer_configurations() const;
 
   private:
-    std::function<ByteVector(ConstByteSpan, size_t&, size_t&)> scale_fun_;
-    std::function<void(ByteVector&, ConstByteSpan)> average2_fun_;
+    using ScaleFunT = std::function<
+      ByteVector(ConstByteSpan, size_t&, size_t&, ZarrDownsamplingMethod)>;
+    using Average2FunT =
+      std::function<void(ByteVector&, ConstByteSpan, ZarrDownsamplingMethod)>;
+
+    ZarrDownsamplingMethod method_;
+
+    ScaleFunT scale_fun_;
+    Average2FunT average2_fun_;
 
     std::unordered_map<int, ArrayWriterConfig> writer_configurations_;
     std::unordered_map<int, ByteVector> downsampled_frames_;

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -537,6 +537,12 @@ ZarrStream_s::validate_settings_(const struct ZarrStreamSettings_s* settings)
         }
     }
 
+    if (settings->downsampling_method >= ZarrDownsamplingMethodCount) {
+        error_ = "Invalid downsampling method: " +
+                 std::to_string(settings->downsampling_method);
+        return false;
+    }
+
     return true;
 }
 
@@ -738,7 +744,7 @@ ZarrStream_s::create_downsampler_()
     const auto config = make_array_writer_config_();
 
     try {
-        downsampler_ = zarr::Downsampler(config);
+        downsampler_ = zarr::Downsampler(config, downsampling_method_);
     } catch (const std::exception& exc) {
         set_error_("Error creating downsampler: " + std::string(exc.what()));
         return false;

--- a/src/streaming/zarr.stream.hh
+++ b/src/streaming/zarr.stream.hh
@@ -74,6 +74,7 @@ struct ZarrStream_s
     std::shared_ptr<zarr::ThreadPool> thread_pool_;
     std::shared_ptr<zarr::S3ConnectionPool> s3_connection_pool_;
 
+    ZarrDownsamplingMethod downsampling_method_;
     std::optional<zarr::Downsampler> downsampler_;
 
     std::vector<std::unique_ptr<zarr::ArrayWriter>> writers_;


### PR DESCRIPTION
Closes #101.

### Methods supported

- Mean
- Min
- Max

## API changes

A new parameter `downsampling_method` was added to the `StreamSettings` struct (`ZarrStreamSettings` class in Python).