### PR TITLE
Add serializable downsampling methods with reproducible metadata

### DIFF
--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -89,7 +89,7 @@ def test_set_dimensions(settings):
             array_size_px=7,
             chunk_size_px=8,
             shard_size_chunks=9,
-        )
+        ),
     ]
 
     assert len(settings.dimensions) == 3
@@ -194,7 +194,7 @@ def test_set_dimensions_in_constructor():
                 array_size_px=7,
                 chunk_size_px=8,
                 shard_size_chunks=9,
-            )
+            ),
         ]
     )
 
@@ -217,6 +217,7 @@ def test_set_dimensions_in_constructor():
     assert settings.dimensions[2].array_size_px == 7
     assert settings.dimensions[2].chunk_size_px == 8
     assert settings.dimensions[2].shard_size_chunks == 9
+
 
 def test_set_multiscale(settings):
     assert settings.multiscale is False

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -503,7 +503,7 @@ def test_write_custom_metadata(
 
 
 def test_write_transposed_array(
-        store_path: Path,
+    store_path: Path,
 ):
     settings = StreamSettings(
         dimensions=[
@@ -549,7 +549,7 @@ def test_write_transposed_array(
     settings.data_type = DataType.INT32
 
     data = np.random.randint(
-        -2**16,
+        -(2**16),
         2**16 - 1,
         (
             settings.dimensions[0].chunk_size_px,
@@ -559,7 +559,7 @@ def test_write_transposed_array(
             settings.dimensions[3].array_size_px,
         ),
         dtype=np.int32,
-        )
+    )
     data = np.transpose(data, (0, 1, 2, 4, 3))
 
     stream = ZarrStream(settings)
@@ -577,7 +577,7 @@ def test_write_transposed_array(
 
 
 def test_column_ragged_sharding(
-        store_path: Path,
+    store_path: Path,
 ):
     settings = StreamSettings(
         dimensions=[
@@ -609,8 +609,8 @@ def test_column_ragged_sharding(
     settings.data_type = DataType.INT32
 
     data = np.random.randint(
-        -2 ** 16,
-        2 ** 16 - 1,
+        -(2**16),
+        2**16 - 1,
         (
             settings.dimensions[0].array_size_px,
             settings.dimensions[1].array_size_px,
@@ -669,8 +669,8 @@ def test_custom_dimension_units_and_scales(store_path: Path):
     settings.data_type = DataType.INT32
 
     data = np.random.randint(
-        -2 ** 16,
-        2 ** 16 - 1,
+        -(2**16),
+        2**16 - 1,
         (
             settings.dimensions[0].array_size_px,
             settings.dimensions[1].array_size_px,
@@ -710,18 +710,24 @@ def test_custom_dimension_units_and_scales(store_path: Path):
     assert x["type"] == "space"
     assert x["unit"] == "nanometer"
 
-    z_scale, y_scale, x_scale = multiscale["datasets"][0]["coordinateTransformations"][0]["scale"]
+    z_scale, y_scale, x_scale = multiscale["datasets"][0][
+        "coordinateTransformations"
+    ][0]["scale"]
 
     assert z_scale == 0.1
     assert y_scale == 0.9
     assert x_scale == 1.1
 
 
-@pytest.mark.parametrize(("method",),
-                         [(DownsamplingMethod.DECIMATE,),
-                          (DownsamplingMethod.MEAN,),
-                          (DownsamplingMethod.MIN,),
-                          (DownsamplingMethod.MAX,)])
+@pytest.mark.parametrize(
+    ("method",),
+    [
+        (DownsamplingMethod.DECIMATE,),
+        (DownsamplingMethod.MEAN,),
+        (DownsamplingMethod.MIN,),
+        (DownsamplingMethod.MAX,),
+    ],
+)
 def test_2d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
     settings = StreamSettings(
         dimensions=[
@@ -755,8 +761,8 @@ def test_2d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
     settings.downsampling_method = method
 
     data = np.random.randint(
-        -2 ** 16,
-        2 ** 16 - 1,
+        -(2**16),
+        2**16 - 1,
         (
             settings.dimensions[0].array_size_px,
             settings.dimensions[1].array_size_px,
@@ -774,7 +780,7 @@ def test_2d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
 
     group = zarr.open(settings.store_path, mode="r")
     metadata = group.attrs["ome"]["multiscales"][0]["metadata"]
-    method = metadata["method"]
+    saved_method = metadata["method"]
     args = list(map(eval, metadata.get("args", [])))
     kwargs = {k: eval(v) for k, v in metadata.get("kwargs", {}).items()}
 
@@ -790,14 +796,23 @@ def test_2d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
 
     for i in range(downsampled.shape[0]):
         expected = downsampled[i, :, :]
-        actual = eval(method)(full_res[i], *args, **kwargs).astype(data.dtype)
+        actual = eval(saved_method)(full_res[i], *args, **kwargs).astype(
+            data.dtype
+        )
 
         # Check the downsampling method and arguments
         np.testing.assert_array_equal(expected, actual)
 
 
-@pytest.mark.parametrize(("method",),
-                         [(DownsamplingMethod.MEAN,), (DownsamplingMethod.MIN,), (DownsamplingMethod.MAX,)])
+@pytest.mark.parametrize(
+    ("method",),
+    [
+        (DownsamplingMethod.DECIMATE,),
+        (DownsamplingMethod.MEAN,),
+        (DownsamplingMethod.MIN,),
+        (DownsamplingMethod.MAX,),
+    ],
+)
 def test_3d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
     settings = StreamSettings(
         dimensions=[
@@ -832,7 +847,7 @@ def test_3d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
 
     data = np.random.randint(
         0,
-        2 ** 16 - 1,
+        2**16 - 1,
         (
             settings.dimensions[0].array_size_px,
             settings.dimensions[1].array_size_px,
@@ -849,6 +864,11 @@ def test_3d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
     del stream
 
     group = zarr.open(settings.store_path, mode="r")
+    metadata = group.attrs["ome"]["multiscales"][0]["metadata"]
+    saved_method = metadata["method"]
+    args = list(map(eval, metadata.get("args", [])))
+    kwargs = {k: eval(v) for k, v in metadata.get("kwargs", {}).items()}
+
     assert "0" in group
 
     full_res = group["0"]
@@ -859,54 +879,59 @@ def test_3d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
     downsampled = group["1"]
     assert downsampled.shape == (50, 24, 32)
 
-    expected = np.zeros((downsampled.shape[1], downsampled.shape[2]), dtype=data.dtype)
-    if method == DownsamplingMethod.MEAN:
-        for plane in range(downsampled.shape[0]):
-            actual = downsampled[plane, :, :]
+    for i in range(downsampled.shape[0]):
+        expected = downsampled[i, :, :]
 
-            expected = skimage.transform.downscale_local_mean(data[(2 * plane): 2 * (plane + 1), :, :],
-                                                              (2, 2, 2)).astype(
-                data.dtype).squeeze()
+        if method == DownsamplingMethod.MEAN:
+            actual1 = eval(saved_method)(full_res[2 * i], *args, **kwargs)
+            actual2 = eval(saved_method)(full_res[2 * i + 1], *args, **kwargs)
+            actual = ((actual1 + actual2) / 2).astype(data.dtype)
+            np.testing.assert_allclose(
+                actual, expected, atol=1
+            )  # we may round slightly differently than skimage
+            continue
 
-            np.testing.assert_allclose(actual, expected, atol=1)  # we may round slightly differently than skimage
-    elif method == DownsamplingMethod.MIN:
-        for plane in range(downsampled.shape[0]):
-            actual = downsampled[plane, :, :]
+        if method == DownsamplingMethod.DECIMATE:
+            actual = eval(saved_method)(
+                full_res[2 * i], *args, **kwargs
+            ).astype(data.dtype)
+        else:
+            actual1 = eval(saved_method)(
+                full_res[2 * i], *args, **kwargs
+            ).astype(data.dtype)
+            actual2 = eval(saved_method)(
+                full_res[2 * i + 1], *args, **kwargs
+            ).astype(data.dtype)
 
-            for row in range(0, data.shape[1], 2):
-                for col in range(0, data.shape[2], 2):
-                    expected[row // 2, col // 2] = np.min(
-                        data[(2 * plane):2 * (plane + 1), row:row + 2, col:col + 2]
-                    )
+            if method == DownsamplingMethod.MIN:
+                actual = np.minimum(actual1, actual2)
+            elif method == DownsamplingMethod.MAX:
+                actual = np.maximum(actual1, actual2)
+            else:
+                raise ValueError(f"Unknown downsampling method: {method}")
 
-            np.testing.assert_array_equal(actual, expected)
-    elif method == DownsamplingMethod.MAX:
-        for plane in range(downsampled.shape[0]):
-            actual = downsampled[plane, :, :]
-
-            for row in range(0, data.shape[1], 2):
-                for col in range(0, data.shape[2], 2):
-                    expected[row // 2, col // 2] = np.max(
-                        data[(2 * plane):2 * (plane + 1), row:row + 2, col:col + 2]
-                    )
-
-            np.testing.assert_array_equal(actual, expected)
+        np.testing.assert_array_equal(expected, actual)
 
 
-@pytest.mark.parametrize(("output_key", "multiscale"),
-                         [
-                             ("labels", False),
-                             ("path/to/data", False),
-                             ("a/nested/multiscale/group", True),
-                         ])
+@pytest.mark.parametrize(
+    ("output_key", "multiscale"),
+    [
+        ("labels", False),
+        ("path/to/data", False),
+        ("a/nested/multiscale/group", True),
+    ],
+)
 def test_stream_data_to_named_array(
-        settings: StreamSettings,
-        store_path: Path,
-        request: pytest.FixtureRequest,
-        output_key: str,
-        multiscale: bool,
+    settings: StreamSettings,
+    store_path: Path,
+    request: pytest.FixtureRequest,
+    output_key: str,
+    multiscale: bool,
 ):
-    settings.store_path = str(store_path / f"stream_to_named_array_{output_key.replace('/', '_')}.zarr")
+    settings.store_path = str(
+        store_path
+        / f"stream_to_named_array_{output_key.replace('/', '_')}.zarr"
+    )
     settings.version = ZarrVersion.V3
     settings.output_key = output_key
     settings.multiscale = multiscale
@@ -941,7 +966,7 @@ def test_stream_data_to_named_array(
 
     # Navigate through the path to get to the array
     current_group = root_group
-    path_parts = output_key.split('/')
+    path_parts = output_key.split("/")
 
     for part in path_parts:
         assert part in current_group, f"Path part '{part}' not found in group"

--- a/src/streaming/downsampler.cpp
+++ b/src/streaming/downsampler.cpp
@@ -483,6 +483,7 @@ zarr::Downsampler::downsample_3d_(ConstByteSpan frame_data)
         auto it = partial_scaled_frames_.find(i);
         if (it != partial_scaled_frames_.end()) {
             // downsampled is the new frame
+            downsampled.swap(it->second);
             average2_fun_(downsampled, it->second, method_);
             downsampled_frames_.emplace(i, downsampled);
 

--- a/src/streaming/downsampler.cpp
+++ b/src/streaming/downsampler.cpp
@@ -300,6 +300,71 @@ zarr::Downsampler::writer_configurations() const
     return writer_configurations_;
 }
 
+std::string
+zarr::Downsampler::downsampling_method() const
+{
+    switch (method_) {
+        case ZarrDownsamplingMethod_Decimate:
+            return "decimate";
+        case ZarrDownsamplingMethod_Mean:
+            return "local_mean";
+        case ZarrDownsamplingMethod_Min:
+            return "local_min";
+        case ZarrDownsamplingMethod_Max:
+            return "local_max";
+        default:
+            throw std::runtime_error("Invalid downsampling method: " +
+                                     std::to_string(method_));
+    }
+}
+
+nlohmann::json
+zarr::Downsampler::get_metadata() const
+{
+    nlohmann::json metadata;
+    switch (method_) {
+        case ZarrDownsamplingMethod_Mean:
+            metadata["description"] =
+              "The fields in the metadata describe how to reproduce this "
+              "multiscaling in scikit-image. The method and its parameters "
+              "are given here.";
+            metadata["method"] = "skimage.transform.downscale_local_mean";
+            metadata["version"] = "0.25.2";
+            metadata["kwargs"] = { { "factors", "(2, 2)" }, { "cval", "0" } };
+            break;
+        case ZarrDownsamplingMethod_Decimate:
+            metadata["description"] =
+              "Subsampling by taking every 2nd pixel/voxel (top-left corner of "
+              "each 2x2 block). "
+              "Equivalent to numpy array slicing with stride 2.";
+            metadata["method"] = "np.ndarray.__getitem__";
+            metadata["version"] = "2.2.6";
+            metadata["args"] = { "(slice(0, None, 2), slice(0, None, 2))" };
+            break;
+        case ZarrDownsamplingMethod_Min:
+            metadata["description"] =
+              "Minimum pooling over 2x2 blocks. Equivalent to reshaping into "
+              "blocks and taking numpy.min along block dimensions.";
+            metadata["method"] = "skimage.measure.block_reduce";
+            metadata["version"] = "0.25.2";
+            metadata["kwargs"] = { { "func", "np.min" } };
+            break;
+        case ZarrDownsamplingMethod_Max:
+            metadata["description"] =
+              "Maximum pooling over 2x2 blocks. Equivalent to reshaping into "
+              "blocks and taking numpy.max along block dimensions.";
+            metadata["method"] = "skimage.measure.block_reduce";
+            metadata["version"] = "0.25.2";
+            metadata["kwargs"] = { { "func", "np.max" } };
+            break;
+        default:
+            throw std::runtime_error("Invalid downsampling method: " +
+                                     std::to_string(method_));
+    }
+
+    return metadata;
+}
+
 bool
 zarr::Downsampler::is_3d_downsample_() const
 {

--- a/src/streaming/downsampler.hh
+++ b/src/streaming/downsampler.hh
@@ -4,6 +4,8 @@
 #include "array.dimensions.hh"
 #include "array.hh"
 
+#include "nlohmann/json.hpp"
+
 #include <unordered_map>
 
 namespace zarr {
@@ -34,6 +36,9 @@ class Downsampler
 
     const std::unordered_map<int, std::shared_ptr<zarr::ArrayConfig>>&
     writer_configurations() const;
+
+    std::string downsampling_method() const;
+    nlohmann::json get_metadata() const;
 
   private:
     using ScaleFunT = std::function<

--- a/src/streaming/group.cpp
+++ b/src/streaming/group.cpp
@@ -190,18 +190,8 @@ zarr::Group::make_multiscales_metadata_() const
         });
 
         // downsampling metadata
-        multiscales[0]["type"] = "local_mean";
-        multiscales[0]["metadata"] = {
-            { "description",
-              "The fields in the metadata describe how to reproduce this "
-              "multiscaling in scikit-image. The method and its parameters "
-              "are "
-              "given here." },
-            { "method", "skimage.transform.downscale_local_mean" },
-            { "version", "0.21.0" },
-            { "args", "[2]" },
-            { "kwargs", { "cval", 0 } },
-        };
+        multiscales[0]["type"] = downsampler_->downsampling_method();
+        multiscales[0]["metadata"] = downsampler_->get_metadata();
     }
 
     return multiscales;


### PR DESCRIPTION
In #108 we overlooked updating the group-level OME metadata to reflect the new downsampling methods. This PR rectifies that. In particular, we

- Accurately describe downsampling methods in the group-level OME metadata
- Fix a bug in the DECIMATE frame averaging method which incorrectly took the second of a pair of frames
- Provide Python functions in NumPy and scikit-image which replicate the downsampling methods we use
- Test downsampling based on the methods we save in the metadata

We also ran `python -m black` in the `python/tests` directory, which reformatted the test files.