### PR TITLE
Links for pypi and download badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Build](https://github.com/acquire-project/acquire-zarr/actions/workflows/build.yml/badge.svg)](https://github.com/acquire-project/acquire-zarr/actions/workflows/build.yml)
 [![Tests](https://github.com/acquire-project/acquire-zarr/actions/workflows/test.yml/badge.svg)](https://github.com/acquire-project/acquire-zarr/actions/workflows/test_pr.yml)
 [![Chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://acquire-imaging.zulipchat.com/)
-![PyPI - Version](https://img.shields.io/pypi/v/acquire-zarr)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/acquire-zarr)
+[![PyPI - Version](https://img.shields.io/pypi/v/acquire-zarr)](https://pypi.org/project/acquire-zarr)
+[![Downloads](https://static.pepy.tech/badge/acquire-zarr/month)](https://pepy.tech/project/acquire-zarr)
 
 This library supports chunked, compressed, multiscale streaming to [Zarr][], both [version 2][] and [version 3][], with
 [OME-NGFF metadata].


### PR DESCRIPTION
Minor change, just making it so there are links for the badges.

I'm not sure pypi has a UI for download stats, so I point to `pepy` instead.