### PR TITLE
Use `kind` kwarg in `Dimension` constructor

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -116,21 +116,21 @@ def run_acquire_zarr_test(
         [
             aqz.Dimension(
                 name="t",
-                type=aqz.DimensionType.TIME,
+                kind=aqz.DimensionType.TIME,
                 array_size_px=0,
                 chunk_size_px=tchunk_size,
                 shard_size_chunks=1,
             ),
             aqz.Dimension(
                 name="y",
-                type=aqz.DimensionType.SPACE,
+                kind=aqz.DimensionType.SPACE,
                 array_size_px=2048,
                 chunk_size_px=xy_chunk_size,
                 shard_size_chunks=xy_shard_size,
             ),
             aqz.Dimension(
                 name="x",
-                type=aqz.DimensionType.SPACE,
+                kind=aqz.DimensionType.SPACE,
                 array_size_px=2048,
                 chunk_size_px=xy_chunk_size,
                 shard_size_chunks=xy_shard_size,


### PR DESCRIPTION
The benchmark script had a bug where the dimension type was passed in using the keyword argument `type`. This was a problem for two reasons:

1. `type` is a reserved keyword in Python
2. The passed value was being ignored. Instead, the dimension type was defaulting to `DimensionType.SPACE`

After #126, we couldn't get away with this anymore because we now do strict checking on keyword arguments. This PR fixes the keyword and the benchmark script now runs.