### PR TITLE
Remove `S3Connection::is_connection_valid()`

### DIFF
--- a/src/streaming/s3.connection.hh
+++ b/src/streaming/s3.connection.hh
@@ -30,13 +30,6 @@ class S3Connection
     explicit S3Connection(const S3Settings& settings);
     ~S3Connection();
 
-    /**
-     * @brief Test a connection by listing all buckets at this connection's
-     * endpoint.
-     * @returns True if the connection is valid, otherwise false.
-     */
-    bool is_connection_valid();
-
     /* Bucket operations */
 
     /**

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -828,14 +828,6 @@ ZarrStream_s::create_store_(bool overwrite)
                        std::string(e.what()));
             return false;
         }
-
-        // test the S3 connection
-        auto conn = s3_connection_pool_->get_connection();
-        if (!conn->is_connection_valid()) {
-            set_error_("Failed to connect to S3");
-            return false;
-        }
-        s3_connection_pool_->return_connection(std::move(conn));
     } else {
         if (!overwrite) {
             if (fs::is_directory(store_path_)) {

--- a/tests/unit-tests/s3-connection-bucket-exists.cpp
+++ b/tests/unit-tests/s3-connection-bucket-exists.cpp
@@ -44,11 +44,6 @@ main()
     try {
         auto conn = std::make_unique<zarr::S3Connection>(settings);
 
-        if (!conn->is_connection_valid()) {
-            LOG_ERROR("Failed to connect to S3.");
-            return 1;
-        }
-
         if (conn->bucket_exists("")) {
             LOG_ERROR("False positive response for empty bucket name.");
             return 1;

--- a/tests/unit-tests/s3-connection-object-exists-check-false-positives.cpp
+++ b/tests/unit-tests/s3-connection-object-exists-check-false-positives.cpp
@@ -46,11 +46,6 @@ main()
     try {
         auto conn = std::make_unique<zarr::S3Connection>(settings);
 
-        if (!conn->is_connection_valid()) {
-            LOG_ERROR("Failed to connect to S3.");
-            return 1;
-        }
-
         CHECK(conn->bucket_exists(settings.bucket_name));
 
         if (conn->object_exists("", object_name)) {

--- a/tests/unit-tests/s3-connection-put-object.cpp
+++ b/tests/unit-tests/s3-connection-put-object.cpp
@@ -45,10 +45,6 @@ main()
     try {
         auto conn = std::make_unique<zarr::S3Connection>(settings);
 
-        if (!conn->is_connection_valid()) {
-            LOG_ERROR("Failed to connect to S3.");
-            return 1;
-        }
         CHECK(conn->bucket_exists(settings.bucket_name));
         CHECK(conn->delete_object(settings.bucket_name, object_name));
         CHECK(!conn->object_exists(settings.bucket_name, object_name));

--- a/tests/unit-tests/s3-connection-upload-multipart-object.cpp
+++ b/tests/unit-tests/s3-connection-upload-multipart-object.cpp
@@ -45,10 +45,6 @@ main()
     try {
         auto conn = std::make_unique<zarr::S3Connection>(settings);
 
-        if (!conn->is_connection_valid()) {
-            LOG_ERROR("Failed to connect to S3.");
-            return 1;
-        }
         CHECK(conn->bucket_exists(settings.bucket_name));
         CHECK(conn->delete_object(settings.bucket_name, object_name));
         CHECK(!conn->object_exists(settings.bucket_name, object_name));

--- a/tests/unit-tests/s3-sink-write-multipart.cpp
+++ b/tests/unit-tests/s3-sink-write-multipart.cpp
@@ -48,10 +48,6 @@ main()
         auto pool = std::make_shared<zarr::S3ConnectionPool>(1, settings);
 
         auto conn = pool->get_connection();
-        if (!conn->is_connection_valid()) {
-            LOG_ERROR("Failed to connect to S3.");
-            return 1;
-        }
         CHECK(conn->bucket_exists(settings.bucket_name));
         CHECK(conn->delete_object(settings.bucket_name, object_name));
         CHECK(!conn->object_exists(settings.bucket_name, object_name));

--- a/tests/unit-tests/s3-sink-write.cpp
+++ b/tests/unit-tests/s3-sink-write.cpp
@@ -47,10 +47,6 @@ main()
         auto pool = std::make_shared<zarr::S3ConnectionPool>(1, settings);
 
         auto conn = pool->get_connection();
-        if (!conn->is_connection_valid()) {
-            LOG_ERROR("Failed to connect to S3.");
-            return 1;
-        }
         CHECK(conn->bucket_exists(settings.bucket_name));
         CHECK(conn->delete_object(settings.bucket_name, object_name));
         CHECK(!conn->object_exists(settings.bucket_name, object_name));


### PR DESCRIPTION
Removes `is_connection_valid()` from class `S3Connection`. The implementation of `is_connection_valid` depended on being able to list the buckets on a given instance, which they may not be able to do. Since we don't know *a priori* what the user's permissions will be on the instance they're working with, we just remove the verification. Users can check their credentials elsewhere in their script.