### PR TITLE
Add ARM builds for Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - "main"
-  pull_request: # TODO (aliddell): remove this after testing
-    branches:
-      - "main"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,18 @@ jobs:
           submodules: true
 
       - name: Install CMake 3.31
+        if: matrix.platform != 'ubuntu-24.04-arm'
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: "3.31.x"
+
+      - name: Install CMake 3.31 for ARM
+        if: matrix.platform == 'ubuntu-24.04-arm'
+        run: |
+          wget https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-linux-aarch64.tar.gz
+          tar -xzf cmake-3.31.8-linux-aarch64.tar.gz
+          sudo mv cmake-3.31.8-linux-aarch64 /opt/cmake
+          echo "/opt/cmake/bin" >> $GITHUB_PATH
 
       - name: Install vcpkg
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,10 +143,16 @@ jobs:
       - name: Build
         run: python -m build
 
-      - name: Fix wheel for manylinux
-        if: ${{ matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm' }}
+      - name: Fix wheel for manylinux (x86_64)
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
         run: |
           auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_x86_64
+          rm dist/*-linux_*.whl
+
+      - name: Fix wheel for manylinux (arm64)
+        if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
+        run: |
+          auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_aarch64
           rm dist/*-linux_*.whl
 
       - name: Upload wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "main"
+  pull_request: # TODO (aliddell): remove this after testing
+    branches:
+      - "main"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
         platform:
           - "windows-latest"
           - "ubuntu-latest"
+          - "ubuntu-latest-arm"
           - "macos-latest" # arm
           - "macos-13" # x86_64
         include:
@@ -23,6 +24,8 @@ jobs:
             vcpkg_triplet: "x64-windows-static"
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
+          - platform: "ubuntu-latest-arm"
+            vcpkg_triplet: "arm64-linux"
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"
           - platform: "macos-13"
@@ -83,6 +86,7 @@ jobs:
         platform:
           - "windows-latest"
           - "ubuntu-22.04"
+          - "ubuntu-22.04-arm"
           - "macos-latest" # arm
           - "macos-13" # x86_64
         python:
@@ -128,7 +132,7 @@ jobs:
         run: python -m build
 
       - name: Fix wheel for manylinux
-        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        if: ${{ matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm' }}
         run: |
           auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_x86_64
           rm dist/*-linux_*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         platform:
           - "windows-latest"
           - "ubuntu-latest"
-          - "ubuntu-latest-arm"
+          - "ubuntu-24.04-arm"
           - "macos-latest" # arm
           - "macos-13" # x86_64
         include:
@@ -24,7 +24,7 @@ jobs:
             vcpkg_triplet: "x64-windows-static"
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
-          - platform: "ubuntu-latest-arm"
+          - platform: "ubuntu-24.04-arm"
             vcpkg_triplet: "arm64-linux"
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - "v*.*.*"
       - "nightly"
-  pull_request: # TODO (aliddell): remove this after testing
-    branches:
-      - "main"
 
 env:
   BUILD_TYPE: Release
@@ -205,30 +202,30 @@ jobs:
           mv ${{steps.download.outputs.download-path}}/*/*.whl dist
           find ${{steps.download.outputs.download-path}}/ -type f -name *.tar.gz -exec mv {} dist \; -quit
 
-#      - name: Tagged release
-#        if: ${{ github.ref_name != 'nightly' }}
-#        uses: marvinpinto/action-automatic-releases@latest
-#        with:
-#          repo_token: ${{ github.token }}
-#          prerelease: false
-#          files: |
-#            ${{steps.download.outputs.download-path}}/*/*.zip
-#            dist/*.whl
-#
-#      - name: Nightly release
-#        if: ${{ github.ref_name == 'nightly' }}
-#        uses: marvinpinto/action-automatic-releases@latest
-#        with:
-#          repo_token: ${{ secrets.PAT }}
-#          automatic_release_tag: "nightly"
-#          prerelease: true
-#          title: "Nightly Release"
-#          files: |
-#            ${{steps.download.outputs.download-path}}/*/*.zip
-#            dist/*.whl
-#
-#      - name: Publish wheels and sources
-#        if: ${{ github.ref_name != 'nightly' }}
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          skip-existing: true
+      - name: Tagged release
+        if: ${{ github.ref_name != 'nightly' }}
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ github.token }}
+          prerelease: false
+          files: |
+            ${{steps.download.outputs.download-path}}/*/*.zip
+            dist/*.whl
+
+      - name: Nightly release
+        if: ${{ github.ref_name == 'nightly' }}
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.PAT }}
+          automatic_release_tag: "nightly"
+          prerelease: true
+          title: "Nightly Release"
+          files: |
+            ${{steps.download.outputs.download-path}}/*/*.zip
+            dist/*.whl
+
+      - name: Publish wheels and sources
+        if: ${{ github.ref_name != 'nightly' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*.*"
       - "nightly"
+  pull_request: # TODO (aliddell): remove this after testing
+    branches:
+      - "main"
 
 env:
   BUILD_TYPE: Release
@@ -157,10 +160,16 @@ jobs:
       - name: Build
         run: python -m build -o dist
 
-      - name: Fix wheel for manylinux
-        if: ${{ matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm' }}
+      - name: Fix wheel for manylinux (x86_64)
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
         run: |
           auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_x86_64
+          rm dist/*-linux_*.whl
+
+      - name: Fix wheel for manylinux (arm64)
+        if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
+        run: |
+          auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_aarch64
           rm dist/*-linux_*.whl
 
       - name: Upload wheel
@@ -196,30 +205,30 @@ jobs:
           mv ${{steps.download.outputs.download-path}}/*/*.whl dist
           find ${{steps.download.outputs.download-path}}/ -type f -name *.tar.gz -exec mv {} dist \; -quit
 
-      - name: Tagged release
-        if: ${{ github.ref_name != 'nightly' }}
-        uses: marvinpinto/action-automatic-releases@latest
-        with:
-          repo_token: ${{ github.token }}
-          prerelease: false
-          files: |
-            ${{steps.download.outputs.download-path}}/*/*.zip
-            dist/*.whl
-
-      - name: Nightly release
-        if: ${{ github.ref_name == 'nightly' }}
-        uses: marvinpinto/action-automatic-releases@latest
-        with:
-          repo_token: ${{ secrets.PAT }}
-          automatic_release_tag: "nightly"
-          prerelease: true
-          title: "Nightly Release"
-          files: |
-            ${{steps.download.outputs.download-path}}/*/*.zip
-            dist/*.whl
-
-      - name: Publish wheels and sources
-        if: ${{ github.ref_name != 'nightly' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          skip-existing: true
+#      - name: Tagged release
+#        if: ${{ github.ref_name != 'nightly' }}
+#        uses: marvinpinto/action-automatic-releases@latest
+#        with:
+#          repo_token: ${{ github.token }}
+#          prerelease: false
+#          files: |
+#            ${{steps.download.outputs.download-path}}/*/*.zip
+#            dist/*.whl
+#
+#      - name: Nightly release
+#        if: ${{ github.ref_name == 'nightly' }}
+#        uses: marvinpinto/action-automatic-releases@latest
+#        with:
+#          repo_token: ${{ secrets.PAT }}
+#          automatic_release_tag: "nightly"
+#          prerelease: true
+#          title: "Nightly Release"
+#          files: |
+#            ${{steps.download.outputs.download-path}}/*/*.zip
+#            dist/*.whl
+#
+#      - name: Publish wheels and sources
+#        if: ${{ github.ref_name != 'nightly' }}
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         platform:
           - "windows-latest"
           - "ubuntu-latest"
+          - "ubuntu-latest-arm"
           - "macos-latest"
           - "macos-13"
         include:
@@ -24,6 +25,8 @@ jobs:
             vcpkg_triplet: "x64-windows-static"
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
+          - platform: "ubuntu-latest-arm"
+            vcpkg_triplet: "arm64-linux"
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"
           - platform: "macos-13"
@@ -89,6 +92,7 @@ jobs:
         platform:
           - "windows-latest"
           - "ubuntu-22.04"
+          - "ubuntu-22.04-arm"
           - "macos-latest" # arm
           - "macos-13" # x86_64
         python:
@@ -132,7 +136,7 @@ jobs:
           brew install libomp
 
       - name: Install system dependencies
-        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        if: ${{ matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm' }}
         run: |
           sudo apt-get install patchelf
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 90
@@ -145,7 +149,7 @@ jobs:
         run: python -m build -o dist
 
       - name: Fix wheel for manylinux
-        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        if: ${{ matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm' }}
         run: |
           auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_x86_64
           rm dist/*-linux_*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         platform:
           - "windows-latest"
           - "ubuntu-latest"
-          - "ubuntu-latest-arm"
+          - "ubuntu-24.04-arm"
           - "macos-latest"
           - "macos-13"
         include:
@@ -25,7 +25,7 @@ jobs:
             vcpkg_triplet: "x64-windows-static"
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
-          - platform: "ubuntu-latest-arm"
+          - platform: "ubuntu-24.04-arm"
             vcpkg_triplet: "arm64-linux"
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,18 @@ jobs:
           submodules: true
 
       - name: Install CMake 3.31
+        if: matrix.platform != 'ubuntu-24.04-arm'
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: "3.31.x"
+
+      - name: Install CMake 3.31 for ARM
+        if: matrix.platform == 'ubuntu-24.04-arm'
+        run: |
+          wget https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-linux-aarch64.tar.gz
+          tar -xzf cmake-3.31.8-linux-aarch64.tar.gz
+          sudo mv cmake-3.31.8-linux-aarch64 /opt/cmake
+          echo "/opt/cmake/bin" >> $GITHUB_PATH
 
       - name: Install vcpkg
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,14 @@ jobs:
       matrix:
         platform:
           - "ubuntu-latest"
+          - "ubuntu-latest-arm"
           - "windows-latest"
           - "macos-latest"
         include:
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
+          - platform: "ubuntu-latest-arm"
+            vcpkg_triplet: "arm64-linux"
           - platform: "windows-latest"
             vcpkg_triplet: "x64-windows-static"
           - platform: "macos-latest"
@@ -161,6 +164,7 @@ jobs:
       matrix:
         platform:
           - "ubuntu-latest"
+          - "ubuntu-latest-arm"
           - "windows-latest"
           - "macos-latest"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,18 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install CMake 3.31
+        if: matrix.platform != 'ubuntu-24.04-arm'
         uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: "3.31.x"
+
+      - name: Install CMake 3.31 for ARM
+        if: matrix.platform == 'ubuntu-24.04-arm'
+        run: |
+          wget https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-linux-aarch64.tar.gz
+          tar -xzf cmake-3.31.8-linux-aarch64.tar.gz
+          sudo mv cmake-3.31.8-linux-aarch64 /opt/cmake
+          echo "/opt/cmake/bin" >> $GITHUB_PATH
 
       - name: Install vcpkg
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,13 +25,13 @@ jobs:
       matrix:
         platform:
           - "ubuntu-latest"
-          - "ubuntu-latest-arm"
+          - "ubuntu-24.04-arm"
           - "windows-latest"
           - "macos-latest"
         include:
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
-          - platform: "ubuntu-latest-arm"
+          - platform: "ubuntu-24.04-arm"
             vcpkg_triplet: "arm64-linux"
           - platform: "windows-latest"
             vcpkg_triplet: "x64-windows-static"
@@ -164,7 +164,7 @@ jobs:
       matrix:
         platform:
           - "ubuntu-latest"
-          - "ubuntu-latest-arm"
+          - "ubuntu-24.04-arm"
           - "windows-latest"
           - "macos-latest"
 


### PR DESCRIPTION
Adds testing on Ubuntu/ARM runners and ARM64 Linux builds and Python wheels. Future releases on PyPI will be able to support installation from pip on ARM systems without having to pull source and build.