### PR TITLE
Flush file buffers before close on Windows

### DIFF
--- a/src/streaming/sink.hh
+++ b/src/streaming/sink.hh
@@ -25,6 +25,11 @@ class Sink
     [[nodiscard]] virtual bool write(size_t offset, ConstByteSpan data) = 0;
 
   protected:
+    /**
+     * @brief Flush any buffered data to the sink.
+     * @note This should ONLY be called when finalizing the sink.
+     * @return True if the flush was successful, false otherwise.
+     */
     [[nodiscard]] virtual bool flush_() = 0;
 
     friend bool finalize_sink(std::unique_ptr<Sink>&& sink);

--- a/src/streaming/win32/file.sink.impl.cpp
+++ b/src/streaming/win32/file.sink.impl.cpp
@@ -102,6 +102,10 @@ bool
 flush_file(void** handle)
 {
     CHECK(handle);
+    auto* fd = reinterpret_cast<HANDLE*>(*handle);
+    if (fd && *fd != INVALID_HANDLE_VALUE) {
+        return FlushFileBuffers(*fd);
+    }
     return true;
 }
 
@@ -111,6 +115,7 @@ destroy_handle(void** handle)
     auto* fd = reinterpret_cast<HANDLE*>(*handle);
     if (fd) {
         if (*fd != INVALID_HANDLE_VALUE) {
+            FlushFileBuffers(*fd);  // Ensure all buffers are flushed
             CloseHandle(*fd);
         }
         delete fd;


### PR DESCRIPTION
Periodically in CI, one sees errors like [this](https://github.com/acquire-project/acquire-zarr/actions/runs/16203995335/job/45749705977), which suggest that Windows has not flushed all of its internal buffers to disk and completely destroyed the file handle before we attempt to open the dataset with zarr-python. This PR ensures that we explicitly request that flush to happen before destroying the handle, as well as clarifies in the documentation when `Sink::flush_` is called.