### PR TITLE
Update workflow files (use newer actions, better checks)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "main"
       - "prep-for-*"
+  pull_request: # TODO (aliddell) remove
+    branches:
+      - "main"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - "main"
       - "prep-for-*"
-  pull_request: # TODO (aliddell) remove
-    branches:
-      - "main"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.platform_name }} binaries
+          name: ${{ matrix.platform_name }} ${{ matrix.build_type}} binaries
           path: ${{github.workspace}}/*.zip
 
   build-wheel:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,14 +23,19 @@ jobs:
         include:
           - platform: "windows-latest"
             vcpkg_triplet: "x64-windows-static"
+            platform_name: "windows-x86_64"
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
+            platform_name: "linux-x86_64"
           - platform: "ubuntu-24.04-arm"
             vcpkg_triplet: "arm64-linux"
+            platform_name: "linux-aarch64"
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"
+            platform_name: "macos-arm64"
           - platform: "macos-13"
             vcpkg_triplet: "x64-osx"
+            platform_name: "macos-x86_64"
 
     runs-on: ${{ matrix.platform }}
 
@@ -42,7 +47,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -70,7 +75,7 @@ jobs:
         shell: bash
 
       - name: Install OpenMP
-        if: matrix.platform == 'macos-latest' || matrix.platform == 'macos-13'
+        if: startsWith(matrix.platform, 'macos')
         run: |
           brew install libomp
 
@@ -86,7 +91,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{matrix.platform == 'macos-latest' && 'macos-arm64' || (matrix.platform == 'macos-13' && 'macos-x86_64' || matrix.platform)}} ${{matrix.build_type}} binaries
+          name: ${{ matrix.platform_name }} binaries
           path: ${{github.workspace}}/*.zip
 
   build-wheel:
@@ -101,6 +106,11 @@ jobs:
           - "macos-13" # x86_64
         python:
           - "3.13.3"
+        include:
+          - platform: "ubuntu-22.04"
+            arch: "x86_64"
+          - platform: "ubuntu-22.04-arm"
+            arch: "aarch64"
 
     runs-on: ${{ matrix.platform }}
 
@@ -112,12 +122,12 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -133,24 +143,18 @@ jobs:
       - name: Install dependencies
         run: python -m pip install -U pip "pybind11[global]" "cmake<4.0.0" build auditwheel
 
-      - name: Install OpenMP on macOS
-        if: matrix.platform == 'macos-latest' || matrix.platform == 'macos-13'
+      - name: Install OpenMP (macOS)
+        if: startsWith(matrix.platform, 'macos')
         run: |
           brew install libomp
 
       - name: Build
         run: python -m build
 
-      - name: Fix wheel for manylinux (x86_64)
-        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+      - name: Fix wheel for manylinux (Linux)
+        if: startsWith(matrix.platform, 'ubuntu')
         run: |
-          auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_x86_64
-          rm dist/*-linux_*.whl
-
-      - name: Fix wheel for manylinux (arm64)
-        if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
-        run: |
-          auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_aarch64
+          auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_${{ matrix.arch }}
           rm dist/*-linux_*.whl
 
       - name: Upload wheel

--- a/.github/workflows/nightly-tag.yml
+++ b/.github/workflows/nightly-tag.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout local repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -70,7 +70,7 @@ jobs:
         shell: bash
 
       - name: Install OpenMP
-        if: matrix.platform == 'macos-latest' || matrix.platform == 'macos-13'
+        if: startsWith(matrix.platform, 'macos')
         run: |
           brew install libomp
 
@@ -110,6 +110,11 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13.3"
+        include:
+          - platform: "ubuntu-22.04"
+            arch: "x86_64"
+          - platform: "ubuntu-22.04-arm"
+            arch: "aarch64"
 
     runs-on: ${{ matrix.platform }}
 
@@ -121,12 +126,12 @@ jobs:
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 
@@ -140,12 +145,12 @@ jobs:
         shell: bash
 
       - name: Install OpenMP
-        if: matrix.platform == 'macos-latest' || matrix.platform == 'macos-13'
+        if: startsWith(matrix.platform, 'macos')
         run: |
           brew install libomp
 
       - name: Install system dependencies
-        if: ${{ matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm' }}
+        if: startsWith(matrix.platform, 'ubuntu')
         run: |
           sudo apt-get install patchelf
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 90
@@ -157,16 +162,10 @@ jobs:
       - name: Build
         run: python -m build -o dist
 
-      - name: Fix wheel for manylinux (x86_64)
-        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+      - name: Fix wheel for manylinux
+        if: startsWith(matrix.platform, 'ubuntu')
         run: |
-          auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_x86_64
-          rm dist/*-linux_*.whl
-
-      - name: Fix wheel for manylinux (arm64)
-        if: ${{ matrix.platform == 'ubuntu-22.04-arm' }}
-        run: |
-          auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_aarch64
+          auditwheel repair dist/*.whl -w dist --plat manylinux_2_35_${{ matrix.arch }}
           rm dist/*-linux_*.whl
 
       - name: Upload wheel
@@ -189,7 +188,7 @@ jobs:
     permissions: write-all
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v4
         id: download
@@ -203,7 +202,7 @@ jobs:
           find ${{steps.download.outputs.download-path}}/ -type f -name *.tar.gz -exec mv {} dist \; -quit
 
       - name: Tagged release
-        if: ${{ github.ref_name != 'nightly' }}
+        if: github.ref_name != 'nightly'
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ github.token }}
@@ -213,7 +212,7 @@ jobs:
             dist/*.whl
 
       - name: Nightly release
-        if: ${{ github.ref_name == 'nightly' }}
+        if: github.ref_name == 'nightly'
         uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.PAT }}
@@ -225,7 +224,7 @@ jobs:
             dist/*.whl
 
       - name: Publish wheels and sources
-        if: ${{ github.ref_name != 'nightly' }}
+        if: github.ref_name != 'nightly'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
@@ -99,7 +99,7 @@ jobs:
       MINIO_SECRET_KEY: 12345678
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
@@ -178,13 +178,13 @@ jobs:
           - "macos-latest"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.13.3"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,15 +210,3 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -v
-
-      - name: Upload test artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zarr-test-artifacts-python-${{ matrix.platform }}
-          path: |
-            **/*.zarr/
-            /tmp/pytest-of-*/pytest-*/test_*/
-          retention-days: 7
-          if-no-files-found: warn
-          include-hidden-files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,3 +210,15 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -v
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zarr-test-artifacts-python-${{ matrix.platform }}
+          path: |
+            **/*.zarr/
+            /tmp/pytest-of-*/pytest-*/test_*/
+          retention-days: 7
+          if-no-files-found: warn
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,4 +221,5 @@ jobs:
             /tmp/pytest-of-*/pytest-*/test_*/
           retention-days: 7
           if-no-files-found: warn
+          include-hidden-files: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,3 +210,15 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -v
+
+      - name: Upload test artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zarr-test-artifacts-python-${{ matrix.platform }}
+          path: |
+            **/*.zarr/
+            /tmp/pytest-of-*/pytest-*/test_*/
+          retention-days: 7
+          if-no-files-found: warn
+          include-hidden-files: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,16 +210,3 @@ jobs:
 
       - name: Run tests
         run: python -m pytest -v
-
-      - name: Upload test artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: zarr-test-artifacts-python-${{ matrix.platform }}
-          path: |
-            **/*.zarr/
-            /tmp/pytest-of-*/pytest-*/test_*/
-          retention-days: 7
-          if-no-files-found: warn
-          include-hidden-files: true
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Endianness indicator for 1-byte dtypes has been corrected to `|` (not relevant) in Zarr V2 metadata (#138)
+
 ## [0.5.0] - [2025-07-11](https://github.com/acquire-project/acquire-zarr/compare/v0.4.0...v0.5.0)
 
 ### Added

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -1083,9 +1083,10 @@ def test_anisotropic_downsampling(settings: StreamSettings,
 )
 def test_multiarray_metadata_structure(
         settings: StreamSettings,
+        store_path: Path,
         version: ZarrVersion,
 ):
-    settings.store_path = f"multiarray_metadata_test-{2 if version == ZarrVersion.V2 else 3}.zarr"
+    settings.store_path = str(store_path / "multiarray_metadata_test.zarr")
     settings.version = version
 
     # Configure three arrays matching the JSON examples
@@ -1279,7 +1280,3 @@ def test_multiarray_metadata_structure(
     assert array2_group.shape == array2_data.shape
     assert array2_group.dtype == np.uint32
     assert np.array_equal(array2_group, array2_data)
-
-    # cleanup
-    if store_path_obj.is_dir():
-        shutil.rmtree(store_path_obj)

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -552,7 +552,7 @@ def test_write_transposed_array(
             )
         ]
     )
-    settings.store_path = "transposed-array-test.zarr"
+    settings.store_path = str(store_path / "test.zarr")
     settings.version = ZarrVersion.V3
 
     data = np.random.randint(

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -94,8 +94,8 @@ def s3_settings():
 
 @pytest.fixture(scope="function")
 def store_path(tmp_path):
-    yield Path(".")  # Use current directory for easier inspection
-    # shutil.rmtree(tmp_path)
+    yield tmp_path
+    shutil.rmtree(tmp_path)
 
 
 def validate_v2_metadata(store_path: Path):
@@ -552,7 +552,7 @@ def test_write_transposed_array(
             )
         ]
     )
-    settings.store_path = str(store_path / "test.zarr")
+    settings.store_path = "transposed-array-test.zarr"
     settings.version = ZarrVersion.V3
 
     data = np.random.randint(

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -1083,10 +1083,9 @@ def test_anisotropic_downsampling(settings: StreamSettings,
 )
 def test_multiarray_metadata_structure(
         settings: StreamSettings,
-        store_path: Path,
         version: ZarrVersion,
 ):
-    settings.store_path = str(store_path / "multiarray_metadata_test.zarr")
+    settings.store_path = f"multiarray_metadata_test-{2 if version == ZarrVersion.V2 else 3}.zarr"
     settings.version = version
 
     # Configure three arrays matching the JSON examples
@@ -1280,3 +1279,7 @@ def test_multiarray_metadata_structure(
     assert array2_group.shape == array2_data.shape
     assert array2_group.dtype == np.uint32
     assert np.array_equal(array2_group, array2_data)
+
+    # cleanup
+    if store_path_obj.is_dir():
+        shutil.rmtree(store_path_obj)

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -94,8 +94,8 @@ def s3_settings():
 
 @pytest.fixture(scope="function")
 def store_path(tmp_path):
-    yield tmp_path
-    shutil.rmtree(tmp_path)
+    yield Path(".")  # Use current directory for easier inspection
+    # shutil.rmtree(tmp_path)
 
 
 def validate_v2_metadata(store_path: Path):

--- a/src/streaming/v2.array.cpp
+++ b/src/streaming/v2.array.cpp
@@ -24,7 +24,7 @@ sample_type_to_dtype(ZarrDataType t, std::string& t_str)
 
     switch (t) {
         case ZarrDataType_uint8:
-            t_str = dtype_prefix + "u1";
+            t_str = "|u1"; // byte order does not matter for 1-byte types
             break;
         case ZarrDataType_uint16:
             t_str = dtype_prefix + "u2";
@@ -36,7 +36,7 @@ sample_type_to_dtype(ZarrDataType t, std::string& t_str)
             t_str = dtype_prefix + "u8";
             break;
         case ZarrDataType_int8:
-            t_str = dtype_prefix + "i1";
+            t_str = "|i1"; // byte order does not matter for 1-byte types
             break;
         case ZarrDataType_int16:
             t_str = dtype_prefix + "i2";

--- a/tests/unit-tests/v2-array-write-ragged-append-dim.cpp
+++ b/tests/unit-tests/v2-array-write-ragged-append-dim.cpp
@@ -35,8 +35,8 @@ check_json()
     std::ifstream f(zarray_path);
     nlohmann::json zarray = nlohmann::json::parse(f);
 
-    EXPECT(zarray["dtype"].get<std::string>() == "<u1",
-           "Expected dtype to be <u1, but got ",
+    EXPECT(zarray["dtype"].get<std::string>() == "|u1",
+           "Expected dtype to be |u1, but got ",
            zarray["dtype"].get<std::string>().c_str());
 
     EXPECT_EQ(int, zarray["zarr_format"].get<int>(), 2);


### PR DESCRIPTION
Also fixes the endianness indicator (`|` for "not relevant") in the `dtype` field for u8 and i8 types when writing Zarr V2 metadata.