### PR TITLE
Default to ZarrV3 in the Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Default to streaming Zarr V3 in Python API (#142)
+
 ## [0.5.1] - [2025-07-24](https://github.com/acquire-project/acquire-zarr/compare/v0.5.0...v0.5.1)
 
 ### Added

--- a/python/acquire-zarr-py.cpp
+++ b/python/acquire-zarr-py.cpp
@@ -355,7 +355,7 @@ class PyZarrStreamSettings
   private:
     std::string store_path_;
     std::optional<PyZarrS3Settings> s3_settings_{ std::nullopt };
-    ZarrVersion version_{ ZarrVersion_2 };
+    ZarrVersion version_{ ZarrVersion_3 };
     unsigned int max_threads_{ std::thread::hardware_concurrency() };
     bool overwrite_{ false };
     std::vector<PyZarrArraySettings> arrays_;

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -224,11 +224,10 @@ def test_set_dimensions_in_constructor():
 
 
 def test_set_version(settings):
-    assert settings.version == aqz.ZarrVersion.V2
-
-    settings.version = aqz.ZarrVersion.V3
-
     assert settings.version == aqz.ZarrVersion.V3
+
+    settings.version = aqz.ZarrVersion.V2
+    assert settings.version == aqz.ZarrVersion.V2
 
 
 def test_set_max_threads(settings):


### PR DESCRIPTION
Until now, if users wanted to stream to Zarr V3 in Python, they would need to specify that in the `StreamSettings` object because the default was Zarr V2. Now they will no longer need to do that.