### PR TITLE
Fix MANIFEST.in to reënable wheel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - "main"
       - "prep-for-*"
-  pull_request: # TODO (aliddell): remove after testing
-    branches:
-      - "main"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - "main"
       - "prep-for-*"
+  pull_request: # TODO (aliddell): remove after testing
+    branches:
+      - "main"
 
 jobs:
   build:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include CMakeLists.txt
 include CMakePresets.json
 include vcpkg.json
 include vcpkg-configuration.json
-include cmake/*.cmake
+include cmake/*
 recursive-include src *
 recursive-include include *
 recursive-include python *


### PR DESCRIPTION
After #143, wheel builds were broken on the Mac. Turns out we needed to include acquire-zarrConfig.cmake.in in MANIFEST.in. This PR corrects that.