### PR TITLE
Implement acquisition/well/plate internal logic

### DIFF
--- a/src/streaming/CMakeLists.txt
+++ b/src/streaming/CMakeLists.txt
@@ -48,6 +48,8 @@ add_library(${tgt}
         v2.multiscale.array.cpp
         v3.multiscale.array.hh
         v3.multiscale.array.cpp
+        plate.hh
+        plate.cpp
         $<TARGET_OBJECTS:acquire-logger-obj>
 )
 

--- a/src/streaming/plate.cpp
+++ b/src/streaming/plate.cpp
@@ -1,0 +1,342 @@
+#include "macros.hh"
+#include "plate.hh"
+
+#include <algorithm>
+#include <regex>
+#include <unordered_set>
+
+nlohmann::json
+zarr::Acquisition::to_json() const
+{
+    // Each acquisition object MUST contain an id key whose value MUST be an
+    // unique integer identifier greater than or equal to 0 within the context
+    // of the plate to which fields of view can refer to (see #well-md). Each
+    // acquisition object SHOULD contain a name key whose value MUST be a string
+    // identifying the name of the acquisition. Each acquisition object SHOULD
+    // contain a maximumfieldcount key whose value MUST be a positive integer
+    // indicating the maximum number of fields of view for the acquisition. Each
+    // acquisition object MAY contain a description key whose value MUST be a
+    // string specifying a description for the acquisition. Each acquisition
+    // object MAY contain a starttime and/or endtime key whose values MUST be
+    // integer epoch timestamps specifying the start and/or end timestamp of the
+    // acquisition.
+    nlohmann::json j;
+    j["id"] = id;
+    if (name.has_value()) {
+        j["name"] = name.value();
+    }
+    if (description.has_value()) {
+        j["description"] = description.value();
+    }
+    if (start_time.has_value()) {
+        j["starttime"] = start_time.value();
+    }
+    if (end_time.has_value()) {
+        j["endtime"] = end_time.value();
+    }
+
+    return j;
+}
+
+zarr::Plate::Plate(const std::string& path,
+                   const std::string& name,
+                   const std::vector<std::string>& row_names,
+                   const std::vector<std::string>& column_names,
+                   const std::vector<Well>& wells,
+                   const std::optional<std::vector<Acquisition>>& acquisitions)
+  : path_(path)
+  , name_(name)
+  , row_names_(row_names)
+  , column_names_(column_names)
+  , wells_(wells)
+  , acquisitions_(acquisitions)
+  , field_count_(0)
+{
+    compute_field_counts_();
+    validate_acquisitions_();
+    validate_wells_();
+}
+
+const std::string&
+zarr::Plate::path() const
+{
+    return path_;
+}
+
+const std::string&
+zarr::Plate::name() const
+{
+    return name_;
+}
+
+const std::vector<zarr::Well>&
+zarr::Plate::wells() const
+{
+    return wells_;
+}
+
+const std::optional<std::vector<zarr::Acquisition>>&
+zarr::Plate::acquisitions() const
+{
+    return acquisitions_;
+}
+
+uint32_t
+zarr::Plate::field_count() const
+{
+    return field_count_;
+}
+
+uint32_t
+zarr::Plate::maximum_field_count(uint32_t acquisition) const
+{
+    auto it = max_field_counts_.find(acquisition);
+    EXPECT(it != max_field_counts_.end(),
+           "Acquisition ID not found in plate: " + std::to_string(acquisition));
+    return it->second;
+}
+
+const std::vector<std::string>&
+zarr::Plate::column_names() const
+{
+    return column_names_;
+}
+
+const std::vector<std::string>&
+zarr::Plate::row_names() const
+{
+    return row_names_;
+}
+
+void
+zarr::Plate::compute_field_counts_()
+{
+    // Each acquisition object SHOULD contain a `maximumfieldcount` key whose
+    // value MUST be a positive integer indicating the maximum number of fields
+    // of view for the acquisition.
+    for (const auto& well : wells_) {
+        std::unordered_map<uint32_t, uint32_t> well_field_counts;
+
+        for (const auto& image : well.images) {
+            if (well_field_counts.find(image.acquisition_id) ==
+                well_field_counts.end()) {
+                well_field_counts[image.acquisition_id] = 0;
+            }
+
+            ++well_field_counts[image.acquisition_id];
+        }
+
+        for (const auto& [acq_id, count] : well_field_counts) {
+            if (max_field_counts_.find(acq_id) == max_field_counts_.end()) {
+                max_field_counts_[acq_id] = 0;
+            }
+
+            max_field_counts_[acq_id] =
+              std::max(max_field_counts_[acq_id], count);
+        }
+    }
+
+    // The plate dictionary SHOULD contain a field_count key whose value MUST be
+    // a positive integer defining the maximum number of fields per view across
+    // all wells.
+    field_count_ = 0;
+    for (const auto& well : wells_) {
+        uint32_t well_count = 0;
+        for (const auto& image : well.images) {
+            ++well_count;
+        }
+        field_count_ = std::max(field_count_, well_count);
+    }
+}
+
+void
+zarr::Plate::validate_acquisitions_()
+{
+    if (!acquisitions_.has_value()) {
+        EXPECT(max_field_counts_.empty(),
+               "Wells contain acquisitions but no acquisitions were given");
+
+        return;
+    }
+
+    // Each acquisition object MUST contain an id key whose value MUST be an
+    // unique integer identifier greater than or equal to 0 within the context
+    // of the plate to which fields of view can refer to.
+    std::unordered_set<uint32_t> unique_ids;
+    for (const auto& acq : *acquisitions_) {
+        EXPECT(unique_ids.find(acq.id) == unique_ids.end(),
+               "Duplicate acquisition ID: ",
+               acq.id);
+        unique_ids.insert(acq.id);
+    }
+
+    for (const auto& [acq_id, count] : max_field_counts_) {
+        EXPECT(unique_ids.find(acq_id) != unique_ids.end(),
+               "Acquisition ID ",
+               acq_id,
+               " found in wells but not in acquisitions");
+    }
+}
+
+void
+zarr::Plate::validate_wells_()
+{
+    std::regex valid_name_regex("^[A-Za-z0-9]+$");
+
+    // Each defined row MUST contain a name key whose value MUST be a string
+    // defining the row name. The name MUST contain only alphanumeric
+    // characters, MUST be case-sensitive, and MUST NOT be a duplicate of any
+    // other name in the rows list. Care SHOULD be taken to avoid collisions on
+    // case-insensitive filesystems (e.g. avoid using both Aa and aA).
+    std::unordered_set<std::string> unique_rows(row_names_.begin(),
+                                                row_names_.end());
+    EXPECT(unique_rows.size() == row_names_.size(),
+           "Row names contain duplicates");
+
+    std::unordered_set<std::string> lowercase_row_names;
+    for (const auto& row : unique_rows) {
+        EXPECT(!row.empty(), "Row name is empty");
+        EXPECT(std::regex_match(row, valid_name_regex),
+               "Row name '" + row + "' contains invalid characters");
+
+        std::string lower_row = row;
+        std::transform(lower_row.begin(),
+                       lower_row.end(),
+                       lower_row.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        lowercase_row_names.insert(lower_row);
+    }
+
+    EXPECT(lowercase_row_names.size() == unique_rows.size(),
+           "Row names contain case-insensitive duplicates");
+
+    // The name MUST contain only alphanumeric characters, MUST be
+    // case-sensitive, and MUST NOT be a duplicate of any other name in the
+    // columns list. Care SHOULD be taken to avoid collisions on
+    // case-insensitive filesystems (e.g. avoid using both Aa and aA).
+    std::unordered_set<std::string> unique_columns(column_names_.begin(),
+                                                   column_names_.end());
+    EXPECT(unique_columns.size() == column_names_.size(),
+           "Column names contain duplicates");
+
+    std::unordered_set<std::string> lowercase_column_names;
+    for (const auto& column : unique_columns) {
+        EXPECT(!column.empty(), "Column name is empty");
+        EXPECT(std::regex_match(column, valid_name_regex),
+               "Column name '" + column + "' contains invalid characters");
+
+        std::string lower_column = column;
+        std::transform(lower_column.begin(),
+                       lower_column.end(),
+                       lower_column.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        lowercase_column_names.insert(lower_column);
+    }
+
+    EXPECT(lowercase_column_names.size() == unique_columns.size(),
+           "Column names contain case-insensitive duplicates");
+
+    // make sure all the well row/col names are in the unique lists
+    for (const auto& well : wells_) {
+        EXPECT(!well.row_name.empty(), "Well row name is empty");
+        EXPECT(unique_rows.find(well.row_name) != unique_rows.end(),
+               "Well row name '",
+               well.row_name,
+               "' not found in given row names");
+
+        EXPECT(!well.column_name.empty(), "Well column name is empty");
+        EXPECT(unique_columns.find(well.column_name) != unique_columns.end(),
+               "Well column name '",
+               well.column_name,
+               "' not found in given column names");
+    }
+}
+
+nlohmann::json
+zarr::Plate::to_json() const
+{
+    // See https://ngff.openmicroscopy.org/latest/#plate-md
+    nlohmann::json j;
+
+    // The plate dictionary MUST contain a version key whose value MUST be a
+    // string specifying the version of the plate specification.
+    j["version"] = "0.5";
+
+    // The plate dictionary SHOULD contain a name key whose value MUST be a
+    // string defining the name of the plate.
+    j["name"] = name_;
+
+    // The plate dictionary SHOULD contain a field_count key whose value MUST be
+    // a positive integer defining the maximum number of fields per view across
+    // all wells.
+    j["field_count"] = field_count_;
+
+    // The plate dictionary MUST contain a rows key whose value MUST be a list
+    // of JSON objects defining the rows of the plate. Each row object defines
+    // the properties of the row at the index of the object in the list. Each
+    // row in the physical plate MUST be defined, even if no wells in the row
+    // are defined. Each defined row MUST contain a name key whose value MUST be
+    // a string defining the row name. The name MUST contain only alphanumeric
+    // characters, MUST be case-sensitive, and MUST NOT be a duplicate of any
+    // other name in the rows list. Care SHOULD be taken to avoid collisions on
+    // case-insensitive filesystems (e.g. avoid using both Aa and aA).
+    j["rows"] = nlohmann::json::array();
+    for (const auto& row : row_names_) {
+        j["rows"].push_back({ { "name", row } });
+    }
+
+    // The plate dictionary MUST contain a columns key whose value MUST be a
+    // list of JSON objects defining the columns of the plate. Each column
+    // object defines the properties of the column at the index of the object in
+    // the list. Each column in the physical plate MUST be defined, even if no
+    // wells in the column are defined. Each column object MUST contain a name
+    // key whose value is a string specifying the column name. The name MUST
+    // contain only alphanumeric characters, MUST be case-sensitive, and MUST
+    // NOT be a duplicate of any other name in the columns list. Care SHOULD be
+    // taken to avoid collisions on case-insensitive filesystems (e.g. avoid
+    // using both Aa and aA).
+    j["columns"] = nlohmann::json::array();
+    for (const auto& column : column_names_) {
+        j["columns"].push_back({ { "name", column } });
+    }
+
+    // The plate dictionary MUST contain a wells key whose value MUST be a list
+    // of JSON objects defining the wells of the plate. Each well object MUST
+    // contain a path key whose value MUST be a string specifying the path to
+    // the well subgroup. The path MUST consist of a name in the rows list, a
+    // file separator (/), and a name from the columns list, in that order. The
+    // path MUST NOT contain additional leading or trailing directories. Each
+    // well object MUST contain both a rowIndex key whose value MUST be an
+    // integer identifying the index into the rows list and a columnIndex key
+    // whose value MUST be an integer identifying the index into the columns
+    // list. rowIndex and columnIndex MUST be 0-based. The rowIndex,
+    // columnIndex, and path MUST all refer to the same row/column pair.
+    j["wells"] = nlohmann::json::array();
+    for (const auto& well : wells_) {
+        nlohmann::json w;
+        w["path"] = well.row_name + "/" + well.column_name;
+        w["rowIndex"] = static_cast<uint32_t>(std::distance(
+          row_names_.begin(),
+          std::find(row_names_.begin(), row_names_.end(), well.row_name)));
+        w["columnIndex"] = static_cast<uint32_t>(std::distance(
+          column_names_.begin(),
+          std::find(
+            column_names_.begin(), column_names_.end(), well.column_name)));
+
+        j["wells"].push_back(w);
+    }
+
+    // The plate dictionary MAY contain an acquisitions key whose value MUST be
+    // a list of JSON objects defining the acquisitions for a given plate to
+    // which wells can refer to.
+    if (acquisitions_.has_value()) {
+        j["acquisitions"] = nlohmann::json::array();
+        for (const auto& acq : *acquisitions_) {
+            j["acquisitions"].push_back(acq.to_json());
+            j["acquisitions"].back()["maximumfieldcount"] =
+              maximum_field_count(acq.id); // MUST be added here
+        }
+    }
+
+    return j;
+}

--- a/src/streaming/plate.hh
+++ b/src/streaming/plate.hh
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace zarr {
+struct FieldOfView
+{
+    uint32_t acquisition_id;
+    std::string path; // relative to the well: base_path/row/col/fov_path
+};
+
+struct Well
+{
+    std::string base_path;
+    std::string row_name;
+    std::string column_name; // metadata: base_path/row_name/col_name/zarr.json
+    std::vector<FieldOfView> images;
+};
+
+struct Acquisition
+{
+    uint32_t id; /// unique identifier (mandatory)
+    std::optional<std::string> name;
+    std::optional<std::string> description;
+    std::optional<uint64_t> start_time;
+    std::optional<uint64_t> end_time;
+
+    nlohmann::json to_json() const;
+};
+
+struct Plate
+{
+    Plate(const std::string& path,
+          const std::string& name,
+          const std::vector<std::string>& row_names,
+          const std::vector<std::string>& column_names,
+          const std::vector<Well>& wells,
+          const std::optional<std::vector<Acquisition>>& acquisitions =
+            std::nullopt);
+
+    const std::string& path() const;
+    const std::string& name() const;
+    const std::vector<Well>& wells() const;
+    const std::optional<std::vector<Acquisition>>& acquisitions() const;
+
+    uint32_t field_count() const;
+    uint32_t maximum_field_count(uint32_t acquisition) const;
+    const std::vector<std::string>& row_names() const;
+    const std::vector<std::string>& column_names() const;
+
+    nlohmann::json to_json() const;
+
+  private:
+    std::string path_;
+    std::string name_;
+    std::vector<std::string> row_names_;
+    std::vector<std::string> column_names_;
+    std::vector<Well> wells_;
+    std::optional<std::vector<Acquisition>> acquisitions_;
+
+    uint32_t field_count_;
+    std::unordered_map<uint32_t, uint32_t> max_field_counts_;
+
+    void compute_field_counts_();
+    void validate_acquisitions_();
+    void validate_wells_();
+};
+} // namespace zarr

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -30,6 +30,7 @@ set(tests
         frame-queue
         downsampler
         downsampler-odd-z
+        plate
 )
 
 foreach (name ${tests})

--- a/tests/unit-tests/plate.cpp
+++ b/tests/unit-tests/plate.cpp
@@ -1,0 +1,403 @@
+#include "plate.hh"
+#include "unit.test.macros.hh"
+
+void
+check_dense_plate()
+{
+    std::string path = "/data/plate";
+    std::string name = "Test Plate";
+
+    std::vector<zarr::Well> wells;
+    wells.emplace_back(zarr::Well{
+      .base_path = path,
+      .row_name = "A",
+      .column_name = "1",
+      .images = { zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1" },
+                  zarr::FieldOfView{ .acquisition_id = 1, .path = "fov2" } } });
+
+    wells.emplace_back(zarr::Well{
+      .base_path = path,
+      .row_name = "A",
+      .column_name = "2",
+      .images = {
+        zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1-1" },
+        zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1-2" },
+        zarr::FieldOfView{ .acquisition_id = 2, .path = "fov2-1" },
+        zarr::FieldOfView{ .acquisition_id = 2, .path = "fov2-2" } } });
+
+    wells.emplace_back(zarr::Well{
+      .base_path = path,
+      .row_name = "A",
+      .column_name = "3",
+      .images = { zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1" } } });
+
+    wells.emplace_back(zarr::Well{
+      .base_path = path,
+      .row_name = "B",
+      .column_name = "1",
+      .images = { zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1" } } });
+
+    wells.emplace_back(zarr::Well{
+      .base_path = path,
+      .row_name = "B",
+      .column_name = "2",
+      .images = { zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1" } } });
+
+    wells.emplace_back(zarr::Well{
+      .base_path = path,
+      .row_name = "B",
+      .column_name = "3",
+      .images = { zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1" },
+                  zarr::FieldOfView{ .acquisition_id = 1, .path = "fov2" },
+                  zarr::FieldOfView{ .acquisition_id = 1, .path = "fov3" } } });
+
+    std::vector<zarr::Acquisition> acquisitions{
+        zarr::Acquisition{ .id = 1, .name = "Acquisition 0" },
+        zarr::Acquisition{ .id = 2, .name = "Acquisition 1" }
+    };
+
+    zarr::Plate plate(
+      path, name, { "A", "B" }, { "1", "2", "3" }, wells, acquisitions);
+
+    EXPECT(plate.path() == path,
+           "Plate path mismatch: Expected ",
+           path,
+           " got ",
+           plate.path());
+
+    EXPECT(plate.name() == name,
+           "Plate name mismatch: Expected ",
+           name,
+           " got ",
+           plate.name());
+
+    const auto& rows = plate.row_names();
+    EXPECT(rows.size() == 2,
+           "Expected 2 rows, got " + std::to_string(rows.size()));
+    EXPECT(rows[0] == "A", "Expected row 0 to be 'A', got '" + rows[0] + "'");
+    EXPECT(rows[1] == "B", "Expected row 1 to be 'B', got '" + rows[1] + "'");
+
+    const auto& columns = plate.column_names();
+    EXPECT(columns.size() == 3,
+           "Expected 3 columns, got " + std::to_string(columns.size()));
+    EXPECT(columns[0] == "1",
+           "Expected column 0 to be '1', got '" + columns[0] + "'");
+    EXPECT(columns[1] == "2",
+           "Expected column 1 to be '2', got '" + columns[1] + "'");
+    EXPECT(columns[2] == "3",
+           "Expected column 2 to be '3', got '" + columns[2] + "'");
+
+    EXPECT(plate.field_count() == 4,
+           "Expected field count to be 4, got ",
+           plate.field_count());
+    EXPECT(plate.maximum_field_count(1) == 3,
+           "Expected max field count for Acquisition 0 to be 3, got ",
+           plate.maximum_field_count(1));
+    EXPECT(plate.maximum_field_count(2) == 2,
+           "Expected max field count for acquisition 2 to be 2, got ",
+           plate.maximum_field_count(2));
+
+    // there should be two acquisitions
+    EXPECT(plate.acquisitions().has_value(), "Expected some acquisitions");
+    std::vector<zarr::Acquisition> test_acquisitions = *plate.acquisitions();
+
+    EXPECT(test_acquisitions.size() == 2,
+           "Expected 2 acquisitions, got ",
+           test_acquisitions.size());
+
+    EXPECT(test_acquisitions[0].id == 1,
+           "Expected acquisition 0 id to be 1, got ",
+           test_acquisitions[0].id);
+    EXPECT(test_acquisitions[0].name.has_value(),
+           "Expected acquisition 0 to have a name");
+    EXPECT(test_acquisitions[0].name.value() == "Acquisition 0",
+           "Expected acquisition 0 name to be 'Acquisition 0', got '",
+           test_acquisitions[0].name.value());
+
+    EXPECT(test_acquisitions[1].id == 2,
+           "Expected acquisition 1 id to be 2, got ",
+           test_acquisitions[1].id);
+    EXPECT(test_acquisitions[1].name.has_value(),
+           "Expected acquisition 1 to have a name");
+    EXPECT(test_acquisitions[1].name.value() == "Acquisition 1",
+           "Expected acquisition 1 name to be 'Acquisition 1', got '",
+           test_acquisitions[1].name.value());
+
+    auto json = plate.to_json();
+
+    EXPECT(json.contains("name"), "Plate JSON missing 'name' key");
+    EXPECT(json["name"] == name,
+           "Plate JSON 'name' key mismatch: Expected ",
+           name,
+           " got ",
+           json["name"].get<std::string>());
+
+    EXPECT(json.contains("field_count"),
+           "Plate JSON missing 'field_count' key");
+    EXPECT(json["field_count"] == 4,
+           "Plate JSON 'field_count' key mismatch: Expected 4 got ",
+           json["field_count"].get<uint32_t>());
+
+    EXPECT(json.contains("rows"), "Plate JSON missing 'rows' key");
+    EXPECT(json["rows"].is_array(), "Plate JSON 'rows' key is not an array");
+    EXPECT(json["rows"].size() == 2,
+           "Plate JSON 'rows' array size mismatch: Expected 2 got ",
+           json["rows"].size());
+
+    EXPECT(json["rows"][0].contains("name"),
+           "Plate JSON 'rows[0]' missing 'name' key");
+    EXPECT(json["rows"][0]["name"].get<std::string>() == "A",
+           "Plate JSON 'rows[0]['name']' mismatch: Expected 'A' got '",
+           json["rows"][0]["name"].get<std::string>(),
+           "'");
+
+    EXPECT(json["rows"][1].contains("name"),
+           "Plate JSON 'rows[1]' missing 'name' key");
+    EXPECT(json["rows"][1]["name"].get<std::string>() == "B",
+           "Plate JSON 'rows[1]['name']' mismatch: Expected 'B' got '",
+           json["rows"][1]["name"].get<std::string>(),
+           "'");
+
+    EXPECT(json.contains("columns"), "Plate JSON missing 'columns' key");
+    EXPECT(json["columns"].is_array(),
+           "Plate JSON 'columns' key is not an array");
+    EXPECT(json["columns"].size() == 3,
+           "Plate JSON 'columns' array size mismatch: Expected 3 got ",
+           json["columns"].size());
+
+    EXPECT(json["columns"][0].contains("name"),
+           "Plate JSON 'columns[0]' missing 'name' key");
+    EXPECT(json["columns"][0]["name"].get<std::string>() == "1",
+           "Plate JSON 'columns[0]['name']' mismatch: Expected '1' got '",
+           json["columns"][0]["name"].get<std::string>(),
+           "'");
+
+    EXPECT(json["columns"][1].contains("name"),
+           "Plate JSON 'columns[1]' missing 'name' key");
+    EXPECT(json["columns"][1]["name"].get<std::string>() == "2",
+           "Plate JSON 'columns[1]['name']' mismatch: Expected '2' got '",
+           json["columns"][1]["name"].get<std::string>(),
+           "'");
+
+    EXPECT(json["columns"][2].contains("name"),
+           "Plate JSON 'columns[2]' missing 'name' key");
+    EXPECT(json["columns"][2]["name"].get<std::string>() == "3",
+           "Plate JSON 'columns[2]['name']' mismatch: Expected '3' got '",
+           json["columns"][2]["name"].get<std::string>(),
+           "'");
+
+    const auto& wells_json = json["wells"];
+    EXPECT(wells_json.is_array(), "Plate JSON 'wells' key is not an array");
+    EXPECT(wells_json.size() == wells.size(),
+           "Plate JSON 'wells' array size mismatch: Expected " +
+             std::to_string(wells.size()) + " got " +
+             std::to_string(wells_json.size()));
+    for (auto i = 0; i < wells_json.size(); ++i) {
+        const auto& well_json = wells_json[i];
+        const auto& well = wells[i];
+
+        EXPECT(well_json.contains("path"),
+               "Plate JSON well missing 'path' key");
+        EXPECT(well_json["path"] == (well.row_name + "/" + well.column_name),
+               "Plate JSON well 'path' key mismatch: Expected ",
+               (well.row_name + "/" + well.column_name),
+               " got ",
+               well_json["path"].get<std::string>());
+
+        EXPECT(well_json.contains("rowIndex"),
+               "Plate JSON well missing 'rowIndex' key");
+        EXPECT(well_json["rowIndex"] ==
+                 static_cast<uint32_t>(i / columns.size()),
+               "Plate JSON well 'rowIndex' key mismatch: Expected ",
+               static_cast<uint32_t>(i / columns.size()),
+               " got ",
+               well_json["rowIndex"].get<uint32_t>());
+
+        EXPECT(well_json.contains("columnIndex"),
+               "Plate JSON well missing 'columnIndex' key");
+        EXPECT(well_json["columnIndex"] ==
+                 static_cast<uint32_t>(i % columns.size()),
+               "Plate JSON well 'columnIndex' key mismatch: Expected ",
+               static_cast<uint32_t>(i % columns.size()),
+               " got ",
+               well_json["columnIndex"].get<uint32_t>());
+
+        EXPECT(json.contains("acquisitions"),
+               "Plate JSON missing 'acquisitions' key");
+        const auto& acqs_json = json["acquisitions"];
+        EXPECT(acqs_json.is_array(),
+               "Plate JSON 'acquisitions' key is not an array");
+        EXPECT(acqs_json.size() == acquisitions.size(),
+               "Plate JSON 'acquisitions' array size mismatch: Expected ",
+               acquisitions.size(),
+               " got ",
+               acqs_json.size());
+
+        for (auto j = 0; j < acqs_json.size(); ++j) {
+            const auto& acq_json = acqs_json[j];
+            const auto& acq = acquisitions[j];
+
+            EXPECT(acq_json.contains("id"),
+                   "Plate JSON acquisition missing 'id' key");
+            EXPECT(acq_json["id"] == acq.id,
+                   "Plate JSON acquisition 'id' key mismatch: Expected ",
+                   acq.id,
+                   " got ",
+                   acq_json["id"].get<uint32_t>());
+            EXPECT(acq_json.contains("name"),
+                   "Plate JSON acquisition missing 'name' key");
+            EXPECT(acq_json["name"] == acq.name.value(),
+                   "Plate JSON acquisition 'name' key mismatch: Expected ",
+                   acq.name.value(),
+                   " got ",
+                   acq_json["name"].get<std::string>());
+
+            EXPECT(acq_json.contains("maximumfieldcount"),
+                   "Plate JSON acquisition missing 'maximumfieldcount' key");
+            EXPECT(acq_json["maximumfieldcount"] ==
+                     plate.maximum_field_count(acq.id),
+                   "Plate JSON acquisition 'maximumfieldcount' key mismatch: "
+                   "Expected ",
+                   plate.maximum_field_count(acq.id),
+                   " got ",
+                   acq_json["maximumfieldcount"].get<uint32_t>());
+
+            EXPECT(!acq_json.contains("description"),
+                   "Plate JSON acquisition should not have 'description' key");
+            EXPECT(!acq_json.contains("starttime"),
+                   "Plate JSON acquisition should not have 'starttime' key");
+            EXPECT(!acq_json.contains("endtime"),
+                   "Plate JSON acquisition should not have 'endtime' key");
+        }
+    }
+}
+
+void
+check_sparse_plate()
+{
+    std::string path = "/data/plate";
+    std::string name = "sparse test";
+    std::vector<zarr::Well> wells;
+    wells.emplace_back(zarr::Well{
+      .base_path = path,
+      .row_name = "C",
+      .column_name = "5",
+      .images = { zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1" } } });
+    wells.emplace_back(zarr::Well{
+      .base_path = path,
+      .row_name = "D",
+      .column_name = "7",
+      .images = { zarr::FieldOfView{ .acquisition_id = 1, .path = "fov1" } } });
+
+    std::vector<zarr::Acquisition> acquisitions{ zarr::Acquisition{
+      .id = 1, .name = "single acquisition", .start_time = 1343731272000ULL } };
+
+    std::vector<std::string> row_names;
+    for (auto i = 0; i < 8; ++i) {
+        row_names.push_back(std::string(1, 'A' + i));
+    }
+
+    std::vector<std::string> column_names;
+    for (auto i = 1; i <= 12; ++i) {
+        column_names.push_back(std::to_string(i));
+    }
+
+    zarr::Plate plate(path, name, row_names, column_names, wells, acquisitions);
+
+    EXPECT(plate.path() == path,
+           "Plate path mismatch: Expected ",
+           path,
+           " got ",
+           plate.path());
+
+    EXPECT(plate.name() == name,
+           "Plate name mismatch: Expected ",
+           name,
+           " got ",
+           plate.name());
+
+    const auto& test_rows = plate.row_names();
+    EXPECT(test_rows.size() == row_names.size(),
+           "Expected ",
+           row_names.size(),
+           " rows, got ",
+           test_rows.size());
+    for (auto i = 0; i < row_names.size(); ++i) {
+        EXPECT(test_rows[i] == row_names[i],
+               "Expected row ",
+               i,
+               " to be '",
+               row_names[i],
+               "', got '",
+               test_rows[i],
+               "'");
+    }
+
+    const auto& test_columns = plate.column_names();
+    EXPECT(test_columns.size() == column_names.size(),
+           "Expected ",
+           column_names.size(),
+           " columns, got ",
+           test_columns.size());
+    for (auto i = 0; i < column_names.size(); ++i) {
+        EXPECT(test_columns[i] == column_names[i],
+               "Expected column ",
+               i,
+               " to be '",
+               column_names[i],
+               "', got '",
+               test_columns[i],
+               "'");
+    }
+
+    EXPECT(plate.field_count() == 1,
+           "Expected field count to be 1, got ",
+           plate.field_count());
+
+    EXPECT(plate.maximum_field_count(1) == 1,
+           "Expected max field count for Acquisition 1 to be 1, got ",
+           plate.maximum_field_count(1));
+
+    // there should be one acquisition
+    EXPECT(plate.acquisitions().has_value(), "Expected some acquisitions");
+    std::vector<zarr::Acquisition> test_acquisitions = *plate.acquisitions();
+    EXPECT(test_acquisitions.size() == 1,
+           "Expected 1 acquisition, got ",
+           test_acquisitions.size());
+    EXPECT(test_acquisitions[0].id == 1,
+           "Expected acquisition 0 id to be 1, got ",
+           test_acquisitions[0].id);
+
+    EXPECT(test_acquisitions[0].name.has_value(),
+           "Expected acquisition 0 to have a name");
+    EXPECT(test_acquisitions[0].name.value() == "single acquisition",
+           "Expected acquisition 0 name to be 'single acquisition', got '",
+           test_acquisitions[0].name.value(),
+           "'");
+    EXPECT(!test_acquisitions[0].description.has_value(),
+           "Expected acquisition 0 to not have a description");
+    EXPECT(test_acquisitions[0].start_time.has_value(),
+           "Expected acquisition 0 to have a start time");
+    EXPECT(test_acquisitions[0].start_time.value() == 1343731272000ULL,
+           "Expected acquisition 0 start time to be 1343731272000, got ",
+           test_acquisitions[0].start_time.value());
+    EXPECT(!test_acquisitions[0].end_time.has_value(),
+           "Expected acquisition 0 to not have an end time");
+}
+
+int
+main()
+{
+    int retval = 1;
+
+    try {
+        check_dense_plate();
+        check_sparse_plate();
+
+        retval = 0;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Exception during Plate test: " + std::string(e.what()));
+    }
+
+    return retval;
+}


### PR DESCRIPTION
This PR implements structs for acquisition, well, and plate pursuant to supporting the [High-Content Screening section](https://ngff.openmicroscopy.org/latest/#hcs-layout) of the NGFF spec.

It doesn't change any behavior in the library, but in the interests of keeping PRs small, I'm submitting this one for your consideration before more extensive changes.