### PR TITLE
Pool file handles to prevent "too many open files" errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     name: Test on ${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -179,7 +179,7 @@ def compare(
     )
 
     time_az_ms, frame_write_times_az = run_acquire_zarr_test(data, az_path, t_chunk_size, xy_chunk_size)
-
+    """
     # use the exact same metadata that was used for the acquire-zarr test
     # to ensure we're using the same chunks and codecs, etc...
     az = zarr.open(az_path)["0"]
@@ -214,10 +214,13 @@ def compare(
     print(
         f"  TensorStore: {time_ts_ms:.3f} ms, {1000 * data_size_gib / time_ts_ms:.3f} GiB/s, 50th percentile frame write time: {np.percentile(frame_write_times_ts, 50):.3f} ms, 99th percentile: {np.percentile(frame_write_times_ts, 99):.3f} ms"
     )
-    print(f"  TS/AZ Ratio: {time_ts_ms / time_az_ms:.3f}")
+    print(f"  TS/AZ Ratio: {time_ts_ms / time_az_ms:.3f}")"""
 
 
 def main():
+    import time
+    time.sleep(10)
+
     T_CHUNK_SIZE = int(sys.argv[1]) if len(sys.argv) > 1 else 64
     XY_CHUNK_SIZE = int(sys.argv[2]) if len(sys.argv) > 2 else 64
     XY_SHARD_SIZE = int(sys.argv[3]) if len(sys.argv) > 3 else 16

--- a/src/streaming/CMakeLists.txt
+++ b/src/streaming/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(tgt acquire-zarr)
 
 if (WIN32)
-    set(PLATFORM_FILE_SINK_CPP win32/file.sink.impl.cpp)
+    set(PLATFORM_CPP win32/platform.cpp)
 else ()
-    set(PLATFORM_FILE_SINK_CPP posix/file.sink.impl.cpp)
+    set(PLATFORM_CPP posix/platform.cpp)
 endif ()
 
 add_library(${tgt}
@@ -27,11 +27,13 @@ add_library(${tgt}
         thread.pool.cpp
         s3.connection.hh
         s3.connection.cpp
+        file.handle.hh
+        file.handle.cpp
         sink.hh
         sink.cpp
         file.sink.hh
         file.sink.cpp
-        ${PLATFORM_FILE_SINK_CPP}
+        ${PLATFORM_CPP}
         s3.sink.hh
         s3.sink.cpp
         array.base.hh

--- a/src/streaming/array.base.hh
+++ b/src/streaming/array.base.hh
@@ -2,7 +2,7 @@
 
 #include "array.dimensions.hh"
 #include "blosc.compression.params.hh"
-#include "definitions.hh"
+#include "file.handle.hh"
 #include "locked.buffer.hh"
 #include "s3.connection.hh"
 #include "sink.hh"
@@ -57,6 +57,7 @@ class ArrayBase
   public:
     ArrayBase(std::shared_ptr<ArrayConfig> config,
               std::shared_ptr<ThreadPool> thread_pool,
+              std::shared_ptr<FileHandlePool> file_handle_pool,
               std::shared_ptr<S3ConnectionPool> s3_connection_pool);
     virtual ~ArrayBase() = default;
 
@@ -83,6 +84,7 @@ class ArrayBase
     std::shared_ptr<ArrayConfig> config_;
     std::shared_ptr<ThreadPool> thread_pool_;
     std::shared_ptr<S3ConnectionPool> s3_connection_pool_;
+    std::shared_ptr<FileHandlePool> file_handle_pool_;
 
     std::unordered_map<std::string, std::string> metadata_strings_;
     std::unordered_map<std::string, std::unique_ptr<Sink>> metadata_sinks_;
@@ -99,6 +101,7 @@ class ArrayBase
 std::unique_ptr<ArrayBase>
 make_array(std::shared_ptr<zarr::ArrayConfig> config,
            std::shared_ptr<ThreadPool> thread_pool,
+           std::shared_ptr<FileHandlePool> file_handle_pool,
            std::shared_ptr<S3ConnectionPool> s3_connection_pool,
            ZarrVersion format);
 

--- a/src/streaming/array.hh
+++ b/src/streaming/array.hh
@@ -16,6 +16,7 @@ class Array : public ArrayBase
   public:
     Array(std::shared_ptr<ArrayConfig> config,
           std::shared_ptr<ThreadPool> thread_pool,
+          std::shared_ptr<FileHandlePool> file_handle_pool,
           std::shared_ptr<S3ConnectionPool> s3_connection_pool);
 
     size_t memory_usage() const noexcept override;
@@ -43,6 +44,7 @@ class Array : public ArrayBase
     virtual const DimensionPartsFun parts_along_dimension_() const = 0;
 
     void make_data_paths_();
+    [[nodiscard]] std::unique_ptr<Sink> make_data_sink_(std::string_view path);
     void fill_buffers_();
 
     bool should_flush_() const;

--- a/src/streaming/definitions.hh
+++ b/src/streaming/definitions.hh
@@ -8,5 +8,3 @@ using ByteVector = std::vector<uint8_t>;
 
 using ByteSpan = std::span<uint8_t>;
 using ConstByteSpan = std::span<const uint8_t>;
-
-constexpr int MAX_CONCURRENT_FILES = 256;

--- a/src/streaming/file.handle.cpp
+++ b/src/streaming/file.handle.cpp
@@ -1,0 +1,64 @@
+#include "definitions.hh"
+#include "file.handle.hh"
+
+#include <chrono>
+
+void*
+init_handle(const std::string& filename, void* flags);
+
+void
+destroy_handle(void* handle);
+
+bool
+flush_file(void* handle);
+
+uint64_t
+get_max_active_handles();
+
+zarr::FileHandle::FileHandle(const std::string& filename, void* flags)
+  : handle_(init_handle(filename, flags))
+{
+}
+
+zarr::FileHandle::~FileHandle()
+{
+    destroy_handle(handle_);
+}
+
+void*
+zarr::FileHandle::get() const
+{
+    return handle_;
+}
+
+zarr::FileHandlePool::FileHandlePool()
+  : max_active_handles_(get_max_active_handles())
+  , n_active_handles_(0)
+{
+}
+
+std::unique_ptr<zarr::FileHandle>
+zarr::FileHandlePool::get_handle(const std::string& filename, void* flags)
+{
+    std::unique_lock lock(mutex_);
+    if (n_active_handles_ >= max_active_handles_) {
+        cv_.wait(lock,
+                 [this]() { return n_active_handles_ < max_active_handles_; });
+    }
+    ++n_active_handles_;
+
+    return std::make_unique<FileHandle>(filename, flags);
+}
+
+void
+zarr::FileHandlePool::return_handle(std::unique_ptr<FileHandle>&& handle)
+{
+    std::unique_lock lock(mutex_);
+
+    if (handle != nullptr && n_active_handles_ > 0) {
+        --n_active_handles_;
+    }
+
+    // handle will be destroyed when going out of scope
+    flush_file(handle->get());
+}

--- a/src/streaming/file.handle.hh
+++ b/src/streaming/file.handle.hh
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <condition_variable>
+#include <memory>  // for std::unique_ptr
+#include <cstddef> // for std::size_t
+#include <mutex>
+#include <string>
+
+namespace zarr {
+class FileHandle
+{
+  public:
+    FileHandle(const std::string& filename, void* flags);
+    ~FileHandle();
+
+    void* get() const;
+
+  private:
+    void* handle_;
+};
+
+class FileHandlePool
+{
+  public:
+    FileHandlePool();
+    ~FileHandlePool() = default;
+
+    std::unique_ptr<FileHandle> get_handle(const std::string& filename,
+                                           void* flags);
+    void return_handle(std::unique_ptr<FileHandle>&& handle);
+
+  private:
+    const uint64_t max_active_handles_;
+    std::atomic<uint64_t> n_active_handles_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+};
+} // namespace zarr

--- a/src/streaming/file.sink.hh
+++ b/src/streaming/file.sink.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "file.handle.hh"
 #include "sink.hh"
 
 #include <fstream>
@@ -9,7 +10,8 @@ namespace zarr {
 class FileSink : public Sink
 {
   public:
-    FileSink(std::string_view filename);
+    FileSink(std::string_view filename,
+             std::shared_ptr<FileHandlePool> file_handle_pool);
     ~FileSink() override;
 
     bool write(size_t offset, ConstByteSpan data) override;
@@ -18,8 +20,9 @@ class FileSink : public Sink
     bool flush_() override;
 
   private:
-    std::mutex mutex_;
+    std::shared_ptr<FileHandlePool> file_handle_pool_;
 
-    void* handle_;
+    std::string filename_;
+    void* flags_;
 };
 } // namespace zarr

--- a/src/streaming/multiscale.array.cpp
+++ b/src/streaming/multiscale.array.cpp
@@ -24,13 +24,13 @@ dimension_type_to_string(ZarrDimensionType type)
 zarr::MultiscaleArray::MultiscaleArray(
   std::shared_ptr<ArrayConfig> config,
   std::shared_ptr<ThreadPool> thread_pool,
+  std::shared_ptr<FileHandlePool> file_handle_pool,
   std::shared_ptr<S3ConnectionPool> s3_connection_pool)
-  : ArrayBase(config, thread_pool, s3_connection_pool)
+  : ArrayBase(config, thread_pool, file_handle_pool, s3_connection_pool)
 {
-    bytes_per_frame_ =
-      config_->dimensions == nullptr
-        ? 0
-        : zarr::bytes_of_frame(*config_->dimensions, config_->dtype);
+    bytes_per_frame_ = config_->dimensions == nullptr
+                         ? 0
+                         : bytes_of_frame(*config_->dimensions, config_->dtype);
 
     EXPECT(create_downsampler_(), "Failed to create downsampler");
 }
@@ -73,7 +73,7 @@ zarr::MultiscaleArray::write_frame(LockedBuffer& data)
 bool
 zarr::MultiscaleArray::close_()
 {
-    for (auto& array: arrays_) {
+    for (auto& array : arrays_) {
         if (!array->close_()) {
             LOG_ERROR("Error closing group: failed to finalize sub-array");
             return false;
@@ -235,4 +235,3 @@ zarr::MultiscaleArray::write_multiscale_frames_(LockedBuffer& data)
         }
     }
 }
-

--- a/src/streaming/multiscale.array.hh
+++ b/src/streaming/multiscale.array.hh
@@ -15,6 +15,7 @@ class MultiscaleArray : public ArrayBase
   public:
     MultiscaleArray(std::shared_ptr<ArrayConfig> config,
                     std::shared_ptr<ThreadPool> thread_pool,
+                    std::shared_ptr<FileHandlePool> file_handle_pool,
                     std::shared_ptr<S3ConnectionPool> s3_connection_pool);
 
     size_t memory_usage() const noexcept override;

--- a/src/streaming/sink.hh
+++ b/src/streaming/sink.hh
@@ -6,8 +6,8 @@
 #include "array.dimensions.hh"
 
 #include <cstddef> // size_t
-#include <memory>  // std::unique_ptr
-#include <span>    // std::span
+#include <file.handle.hh>
+#include <memory> // std::unique_ptr
 
 namespace zarr {
 class Sink
@@ -36,7 +36,7 @@ class Sink
 };
 
 /**
- * @brief Finalize and destroy the Sink @p sink.
+ * @brief Finalize and destroy @p sink.
  * @note @p sink is no longer accessible after a successful call to this
  * function.
  * @param[in] sink The Sink to finalize.
@@ -81,12 +81,14 @@ make_dirs(const std::vector<std::string>& dir_paths,
 /**
  * @brief Create a file sink from a path.
  * @param file_path The path to the file.
+ * @param file_handle_pool Pointer to a pool of file handles.
  * @return Pointer to the sink created, or nullptr if the file cannot be
  * opened.
  * @throws std::runtime_error if the file path is not valid.
  */
 std::unique_ptr<zarr::Sink>
-make_file_sink(std::string_view file_path);
+make_file_sink(std::string_view file_path,
+               std::shared_ptr<FileHandlePool> file_handle_pool);
 
 /**
  * @brief Create a collection of file sinks for a Zarr dataset.
@@ -96,6 +98,7 @@ make_file_sink(std::string_view file_path);
  * parts (i.e., shards or chunks) along a dimension.
  * @param[in] thread_pool Pointer to a thread pool object. Used to create files
  * in parallel.
+ * @param file_handle_pool Pointer to a pool of file handles.
  * @param[out] part_sinks The sinks created.
  * @return True iff all file sinks were created successfully.
  * @throws std::runtime_error if @p base_path is not valid, or if the number
@@ -106,6 +109,7 @@ make_data_file_sinks(std::string_view base_path,
                      const ArrayDimensions& dimensions,
                      const DimensionPartsFun& parts_along_dimension,
                      std::shared_ptr<ThreadPool> thread_pool,
+                     std::shared_ptr<FileHandlePool> file_handle_pool,
                      std::vector<std::unique_ptr<Sink>>& part_sinks);
 
 /**

--- a/src/streaming/thread.pool.hh
+++ b/src/streaming/thread.pool.hh
@@ -48,6 +48,8 @@ class ThreadPool
   private:
     ErrorCallback error_handler_;
 
+    std::thread::id main_thread_id_;
+
     std::vector<std::thread> threads_;
 
     std::atomic<bool> accepting_jobs{ true };
@@ -55,6 +57,7 @@ class ThreadPool
     std::condition_variable jobs_cv_;
     std::queue<Task> jobs_;
 
+    std::vector<std::string> error_messages_;
 
     std::optional<ThreadPool::Task> pop_from_job_queue_() noexcept;
     [[nodiscard]] bool should_stop_() const noexcept;

--- a/src/streaming/v2.array.hh
+++ b/src/streaming/v2.array.hh
@@ -8,6 +8,7 @@ class V2Array final : public Array
   public:
     V2Array(std::shared_ptr<ArrayConfig> config,
             std::shared_ptr<ThreadPool> thread_pool,
+            std::shared_ptr<FileHandlePool> file_handle_pool,
             std::shared_ptr<S3ConnectionPool> s3_connection_pool);
 
   private:

--- a/src/streaming/v2.multiscale.array.cpp
+++ b/src/streaming/v2.multiscale.array.cpp
@@ -5,8 +5,9 @@
 zarr::V2MultiscaleArray::V2MultiscaleArray(
   std::shared_ptr<ArrayConfig> config,
   std::shared_ptr<ThreadPool> thread_pool,
+  std::shared_ptr<FileHandlePool> file_handle_pool,
   std::shared_ptr<S3ConnectionPool> s3_connection_pool)
-  : MultiscaleArray(config, thread_pool, s3_connection_pool)
+  : MultiscaleArray(config, thread_pool, file_handle_pool, s3_connection_pool)
 {
     // dimensions may be null in the case of intermediate groups, e.g., the
     // A in A/1
@@ -51,13 +52,13 @@ zarr::V2MultiscaleArray::create_arrays_()
         arrays_.resize(configs.size());
 
         for (const auto& [lod, config] : configs) {
-            arrays_[lod] = std::make_unique<zarr::V2Array>(
-              config, thread_pool_, s3_connection_pool_);
+            arrays_[lod] = std::make_unique<V2Array>(
+              config, thread_pool_, file_handle_pool_, s3_connection_pool_);
         }
     } else {
         const auto config = make_base_array_config_();
-        arrays_.push_back(std::make_unique<zarr::V2Array>(
-          config, thread_pool_, s3_connection_pool_));
+        arrays_.push_back(std::make_unique<V2Array>(
+          config, thread_pool_, file_handle_pool_, s3_connection_pool_));
     }
 
     return true;

--- a/src/streaming/v2.multiscale.array.hh
+++ b/src/streaming/v2.multiscale.array.hh
@@ -9,6 +9,7 @@ class V2MultiscaleArray final : public MultiscaleArray
   public:
     V2MultiscaleArray(std::shared_ptr<ArrayConfig> config,
                       std::shared_ptr<ThreadPool> thread_pool,
+                      std::shared_ptr<FileHandlePool> file_handle_pool,
                       std::shared_ptr<S3ConnectionPool> s3_connection_pool);
 
   private:

--- a/src/streaming/v3.array.hh
+++ b/src/streaming/v3.array.hh
@@ -8,6 +8,7 @@ class V3Array final : public Array
   public:
     V3Array(std::shared_ptr<ArrayConfig> config,
             std::shared_ptr<ThreadPool> thread_pool,
+            std::shared_ptr<FileHandlePool> file_handle_pool,
             std::shared_ptr<S3ConnectionPool> s3_connection_pool);
 
   private:

--- a/src/streaming/v3.multiscale.array.cpp
+++ b/src/streaming/v3.multiscale.array.cpp
@@ -5,8 +5,9 @@
 zarr::V3MultiscaleArray::V3MultiscaleArray(
   std::shared_ptr<ArrayConfig> config,
   std::shared_ptr<ThreadPool> thread_pool,
+  std::shared_ptr<FileHandlePool> file_handle_pool,
   std::shared_ptr<S3ConnectionPool> s3_connection_pool)
-  : MultiscaleArray(config, thread_pool, s3_connection_pool)
+  : MultiscaleArray(config, thread_pool, file_handle_pool, s3_connection_pool)
 {
     // dimensions may be null in the case of intermediate groups, e.g., the
     // A in A/1
@@ -52,13 +53,13 @@ zarr::V3MultiscaleArray::create_arrays_()
         arrays_.resize(configs.size());
 
         for (const auto& [lod, config] : configs) {
-            arrays_[lod] = std::make_unique<zarr::V3Array>(
-              config, thread_pool_, s3_connection_pool_);
+            arrays_[lod] = std::make_unique<V3Array>(
+              config, thread_pool_, file_handle_pool_, s3_connection_pool_);
         }
     } else {
         const auto config = make_base_array_config_();
-        arrays_.push_back(std::make_unique<zarr::V3Array>(
-          config, thread_pool_, s3_connection_pool_));
+        arrays_.push_back(std::make_unique<V3Array>(
+          config, thread_pool_, file_handle_pool_, s3_connection_pool_));
     }
 
     return true;

--- a/src/streaming/v3.multiscale.array.hh
+++ b/src/streaming/v3.multiscale.array.hh
@@ -9,6 +9,7 @@ class V3MultiscaleArray final : public MultiscaleArray
   public:
     V3MultiscaleArray(std::shared_ptr<ArrayConfig> config,
                       std::shared_ptr<ThreadPool> thread_pool,
+                      std::shared_ptr<FileHandlePool> file_handle_pool,
                       std::shared_ptr<S3ConnectionPool> s3_connection_pool);
 
   private:

--- a/src/streaming/zarr.stream.hh
+++ b/src/streaming/zarr.stream.hh
@@ -4,6 +4,7 @@
 #include "array.dimensions.hh"
 #include "definitions.hh"
 #include "downsampler.hh"
+#include "file.handle.hh"
 #include "frame.queue.hh"
 #include "locked.buffer.hh"
 #include "multiscale.array.hh"
@@ -85,6 +86,7 @@ struct ZarrStream_s
 
     std::shared_ptr<zarr::ThreadPool> thread_pool_;
     std::shared_ptr<zarr::S3ConnectionPool> s3_connection_pool_;
+    std::shared_ptr<zarr::FileHandlePool> file_handle_pool_;
 
     std::unique_ptr<zarr::Sink> custom_metadata_sink_;
 

--- a/tests/unit-tests/file-sink-write.cpp
+++ b/tests/unit-tests/file-sink-write.cpp
@@ -17,7 +17,8 @@ main()
         CHECK(!fs::exists(tmp_path));
         {
             char str[] = "Hello, Acquire!";
-            auto sink = std::make_unique<zarr::FileSink>(tmp_path.string());
+            auto sink = std::make_unique<zarr::FileSink>(
+              tmp_path.string(), std::make_shared<zarr::FileHandlePool>());
 
             std::span data = { reinterpret_cast<uint8_t*>(str),
                                sizeof(str) - 1 };

--- a/tests/unit-tests/v2-array-write-even.cpp
+++ b/tests/unit-tests/v2-array-write-even.cpp
@@ -104,8 +104,11 @@ main()
           level_of_detail);
 
         {
-            auto writer =
-              std::make_unique<zarr::V2Array>(config, thread_pool, nullptr);
+            auto writer = std::make_unique<zarr::V2Array>(
+              config,
+              thread_pool,
+              std::make_shared<zarr::FileHandlePool>(),
+              nullptr);
 
             const size_t frame_size = array_width * array_height * nbytes_px;
             zarr::LockedBuffer data(std::move(ByteVector(frame_size, 0)));

--- a/tests/unit-tests/v2-array-write-frame-to-chunks.cpp
+++ b/tests/unit-tests/v2-array-write-frame-to-chunks.cpp
@@ -25,8 +25,7 @@ main()
 
     try {
         auto thread_pool = std::make_shared<zarr::ThreadPool>(
-          std::thread::hardware_concurrency(),
-          [](const std::string& err) { LOG_ERROR("Error: ", err); });
+          0, [](const std::string& err) { LOG_ERROR("Error: ", err); });
 
         std::vector<ZarrDimension> dims;
         dims.emplace_back(
@@ -50,7 +49,10 @@ main()
           std::nullopt,
           0);
 
-        zarr::V2Array writer(config, thread_pool, nullptr);
+        zarr::V2Array writer(config,
+                             thread_pool,
+                             std::make_shared<zarr::FileHandlePool>(),
+                             nullptr);
 
         const size_t frame_size = array_width * array_height * nbytes_px;
         zarr::LockedBuffer data(std::move(ByteVector(frame_size, 0)));

--- a/tests/unit-tests/v2-array-write-ragged-append-dim.cpp
+++ b/tests/unit-tests/v2-array-write-ragged-append-dim.cpp
@@ -87,8 +87,11 @@ main()
           level_of_detail);
 
         {
-            auto writer =
-              std::make_unique<zarr::V2Array>(config, thread_pool, nullptr);
+            auto writer = std::make_unique<zarr::V2Array>(
+              config,
+              thread_pool,
+              std::make_shared<zarr::FileHandlePool>(),
+              nullptr);
 
             const size_t frame_size = array_width * array_height * nbytes_px;
             zarr::LockedBuffer data(std::move(ByteVector(frame_size, 0)));

--- a/tests/unit-tests/v2-array-write-ragged-internal-dim.cpp
+++ b/tests/unit-tests/v2-array-write-ragged-internal-dim.cpp
@@ -95,8 +95,11 @@ main()
           level_of_detail);
 
         {
-            auto writer =
-              std::make_unique<zarr::V2Array>(config, thread_pool, nullptr);
+            auto writer = std::make_unique<zarr::V2Array>(
+              config,
+              thread_pool,
+              std::make_shared<zarr::FileHandlePool>(),
+              nullptr);
 
             const size_t frame_size = array_width * array_height * nbytes_px;
             zarr::LockedBuffer data(std::move(ByteVector(frame_size, 0)));

--- a/tests/unit-tests/v3-array-write-even.cpp
+++ b/tests/unit-tests/v3-array-write-even.cpp
@@ -142,8 +142,11 @@ main()
           level_of_detail);
 
         {
-            auto writer =
-              std::make_unique<zarr::V3Array>(config, thread_pool, nullptr);
+            auto writer = std::make_unique<zarr::V3Array>(
+              config,
+              thread_pool,
+              std::make_shared<zarr::FileHandlePool>(),
+              nullptr);
 
             const size_t frame_size = array_width * array_height * nbytes_px;
             zarr::LockedBuffer data(std::move(ByteVector(frame_size, 0)));

--- a/tests/unit-tests/v3-array-write-ragged-append-dim.cpp
+++ b/tests/unit-tests/v3-array-write-ragged-append-dim.cpp
@@ -113,8 +113,11 @@ main()
           4);
 
         {
-            auto writer =
-              std::make_unique<zarr::V3Array>(config, thread_pool, nullptr);
+            auto writer = std::make_unique<zarr::V3Array>(
+              config,
+              thread_pool,
+              std::make_shared<zarr::FileHandlePool>(),
+              nullptr);
 
             const size_t frame_size = array_width * array_height * nbytes_px;
             zarr::LockedBuffer data(std::move(ByteVector(frame_size, 0)));

--- a/tests/unit-tests/v3-array-write-ragged-internal-dim.cpp
+++ b/tests/unit-tests/v3-array-write-ragged-internal-dim.cpp
@@ -130,8 +130,11 @@ main()
           5);
 
         {
-            auto writer =
-              std::make_unique<zarr::V3Array>(config, thread_pool, nullptr);
+            auto writer = std::make_unique<zarr::V3Array>(
+              config,
+              thread_pool,
+              std::make_shared<zarr::FileHandlePool>(),
+              nullptr);
 
             const size_t frame_size = array_width * array_height * nbytes_px;
             zarr::LockedBuffer data(std::move(ByteVector(frame_size, 0)));


### PR DESCRIPTION
Introduces a `FileHandlePool` class (similar to `ThreadPool` and `S3ConnectionPool` to manage file handle allocation and prevent exhausting OS limits during concurrent file I/O. This PR actually *increases* in some cases the number of open files that acquire-zarr may have at a time, due to the old scheme being limited by a fixed, more or less arbitrary, constant.

## Changes

- Added `FileHandle` and `FileHandlePool` classes to manage file handle lifecycle
- Pool respects OS limits (via `getrlimit(RLIMIT_NOFILE)` on POSIX, `_getmaxstdio()` on Windows)
- File handles are acquired from pool before write operations and returned after
- Blocks when pool is exhausted until handles become available
- `FileSink` constructor, `ArrayBase` constructors, and the various `make_file_sink` overloads require a `std::shared_ptr<FileHandlePool>`. These changes are BREAKING but internal.