### PR TITLE
Run macOS (Intel) tests on macos-15 runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,7 @@ jobs:
           - "ubuntu-latest"
           - "ubuntu-24.04-arm"
           - "macos-latest" # arm
-          - "macos-13" # x86_64
+          - "macos-15-intel" # x86_64
         include:
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
@@ -28,7 +28,7 @@ jobs:
             vcpkg_triplet: "x64-windows-static"
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"
-          - platform: "macos-13"
+          - platform: "macos-15-intel"
             vcpkg_triplet: "x64-osx"
           - platform: "ubuntu-24.04-arm"
             vcpkg_triplet: "arm64-linux"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           - "ubuntu-latest"
           - "ubuntu-24.04-arm"
           - "macos-latest" # arm
-          - "macos-13" # x86_64
+          - "macos-15-intel" # x86_64
         include:
           - platform: "windows-latest"
             vcpkg_triplet: "x64-windows-static"
@@ -33,7 +33,7 @@ jobs:
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"
             platform_name: "macos-arm64"
-          - platform: "macos-13"
+          - platform: "macos-15-intel"
             vcpkg_triplet: "x64-osx"
             platform_name: "macos-x86_64"
 
@@ -101,7 +101,7 @@ jobs:
         platform:
           - "windows-latest"
           - "macos-latest" # arm
-          - "macos-13" # x86_64
+          - "macos-15-intel" # x86_64
         python:
           - "3.13.3"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - "ubuntu-latest"
           - "ubuntu-24.04-arm"
           - "macos-latest"
-          - "macos-13"
+          - "macos-15-intel"
         include:
           - platform: "windows-latest"
             vcpkg_triplet: "x64-windows-static"
@@ -29,7 +29,7 @@ jobs:
             vcpkg_triplet: "arm64-linux"
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"
-          - platform: "macos-13"
+          - platform: "macos-15-intel"
             vcpkg_triplet: "x64-osx"
 
     runs-on: ${{ matrix.platform }}
@@ -101,7 +101,7 @@ jobs:
         platform:
           - "windows-latest"
           - "macos-latest" # arm
-          - "macos-13" # x86_64
+          - "macos-15-intel" # x86_64
         python:
           - "3.9"
           - "3.10"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           - "ubuntu-24.04-arm"
           - "windows-latest"
           - "macos-latest" # arm
-          - "macos-13" # x86_64
+          - "macos-15-intel" # x86_64
         include:
           - platform: "ubuntu-latest"
             vcpkg_triplet: "x64-linux"
@@ -38,7 +38,7 @@ jobs:
             vcpkg_triplet: "x64-windows-static"
           - platform: "macos-latest"
             vcpkg_triplet: "arm64-osx"
-          - platform: "macos-13"
+          - platform: "macos-15-intel"
             vcpkg_triplet: "x64-osx"
     permissions:
       actions: write
@@ -179,7 +179,7 @@ jobs:
           - "ubuntu-24.04-arm"
           - "windows-latest"
           - "macos-latest" # arm
-          - "macos-13" # x86_64
+          - "macos-15-intel" # x86_64
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
macos-13 runners are now [retired](https://github.com/actions/runner-images/issues/13046)