### PR TITLE
Add max_levels cap and preserve chunk sizes at downsampled pyramid levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ venv.bak/
 *.zarr
 *.csv
 uv.lock
+
+# Claude code
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `max_levels` field on `ZarrArraySettings` (C API) and `ArraySettings` (Python) to cap the maximum number of
+  downsampled pyramid levels; `0` means no limit (default)
+- Stock Zstd compression codec support as a standalone codec without Blosc (#209)
+- Dockerfile for containerized builds (#207)
+
+### Changed
+
+- Chunk sizes at downsampled pyramid levels are now preserved rather than clamped to the array size; a chunk larger
+  than the array produces a single partial chunk, which is valid in Zarr v3
+- Custom metadata is now written under the `attributes` key in `zarr.json` for the target array or group rather than
+  a sidecar file (#201)
+- Documented `output_key` and `downsampling_method` behavior (#206)
+
+### Fixed
+
+- Frame-processing deadlock that could occur when an error was raised during processing (#216) (#221)
+
 ## [0.7.0] - [2026-03-11](https://github.com/acquire-project/acquire-zarr/compare/v0.6.0...v0.7.0)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+**acquire-zarr** is a C/C++ library (with Python bindings via pybind11) for streaming chunked, compressed, multiscale data to Zarr v3 format with OME-NGFF metadata support. It targets high-throughput scientific data acquisition (e.g., high-content screening). Storage backends include local filesystem and S3-compatible object stores.
+
+## Build
+
+Requires CMake 3.23+, a C++20 compiler, and vcpkg (managed via `VCPKG_ROOT`).
+
+```bash
+# Full setup (installs Python env, bootstraps vcpkg, builds everything)
+just install -p 3.13
+
+# C/C++ only
+just cmake-build
+
+# Clean
+just clean
+```
+
+Key CMake flags:
+- `-DBUILD_PYTHON=ON` — build Python bindings
+- `-DBUILD_TESTING=ON` — build test suite (default on)
+- `-DBUILD_BENCHMARK=OFF` — benchmarks (default off)
+- On Windows: `-DVCPKG_TARGET_TRIPLET=x64-windows-static`
+
+Presets are defined in `CMakePresets.json`; the default preset uses the vcpkg toolchain.
+
+## Tests
+
+**C/C++ tests** (CTest):
+```bash
+just test-cpp
+# or directly:
+ctest --test-dir build
+```
+
+Tests under label `s3` require a local MinIO instance on `localhost:9000`.
+
+**Python tests** (pytest, config in `pyproject.toml`):
+```bash
+just test
+# or directly:
+uv run pytest
+# single test file:
+uv run pytest python/tests/test_stream.py
+# single test:
+uv run pytest python/tests/test_stream.py::test_name
+```
+
+S3 tests need env vars: `ZARR_S3_ENDPOINT`, `ZARR_S3_BUCKET_NAME`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`.
+
+## Linting / formatting
+
+Pre-commit hooks run automatically on commit; to run manually:
+```bash
+pre-commit run --all-files
+```
+
+- **C/C++**: `clang-format` (Mozilla style, 80-col, config in `.clang-format`) and `clang-tidy` (`.clang-tidy`)
+- **Python**: `black` (line-length 79, target 3.9–3.13) and `ruff`
+
+## Architecture
+
+### Public interface
+
+- `include/acquire.zarr.h` — C API (the stable public surface)
+- `include/zarr.types.h` — all enums and structs (`ZarrStream*`, `ZarrStreamSettings`, `ZarrArraySettings`, dimension types, compression params, HCS types)
+- `python/acquire-zarr-py.cpp` — pybind11 wrapper; `python/acquire_zarr/` holds the Python-side package
+
+### Core streaming pipeline (`src/streaming/`)
+
+| File | Role |
+|------|------|
+| `zarr.stream.hh/cpp` | `ZarrStream`: top-level manager — accepts frames via `append()`, dispatches to arrays, owns the thread pool and frame queue |
+| `array.hh/cpp` | `ArrayBase`/`Array`: manages chunk layout and data for one array within a store |
+| `array.dimensions.hh/cpp` | Per-dimension metadata (size, chunk size, shard size, transposition order) |
+| `multiscale.array.hh/cpp` | Wraps an `Array` and generates downsampled pyramid levels |
+| `downsampler.hh/cpp` | Mean/mode/median downsampling logic |
+| `chunk.hh/cpp` + `shard.hh/cpp` | Zarr v3 chunk/shard serialization |
+| `frame.queue.hh/cpp` | Thread-safe frame buffer between `append()` caller and writer threads |
+| `thread.pool.hh/cpp` | Worker threads that compress and write chunks; jobs return `TaskStatus` |
+| `sink.hh/cpp` | Abstract write-sink interface |
+| `file.sink.hh/cpp` + `posix/`/`win32/` | Filesystem sink (platform-specific implementation) |
+| `s3.sink.hh/cpp` + `s3.connection.hh/cpp` | S3 sink backed by minio-cpp submodule |
+| `plate.hh/cpp` | HCS plate/well/field-of-view OME-NGFF metadata |
+| `file.handle.hh/cpp` | File handle pool to respect OS open-file limits |
+| `zarr.common.hh/cpp` | Shared types, JSON helpers (nlohmann-json) |
+| `blosc.compression.params`, `zstd.compression.params` | Compression parameter structs |
+
+### Data flow
+
+1. Caller → `ZarrStream::append(frame, array_key)`
+2. Frame pushed onto `FrameQueue` with its frame id
+3. Worker threads pop frames, compress chunks with Blosc or zstd
+4. Compressed chunks assembled into shards (Zarr v3 sharding codec)
+5. Shards and metadata (`.zarray`, `zarr.json`) written atomically via the sink abstraction
+6. For multiscale stores, downsampled levels are written in parallel
+
+### Tests layout
+
+- `tests/unit-tests/` — component-level (dimensions, chunks, downsampling, frame queue, etc.)
+- `tests/integration/` — end-to-end scenarios (filesystem, S3, multiscale, HCS plates)
+- `python/tests/` — Python-binding tests (`test_stream.py`, `test_settings.py`, `test_dimension_transposition.py`)
+
+### Examples and benchmarks
+
+- `examples/` — C and C++ examples; `examples/python/` — Python examples
+- `benchmarks/` — `benchmark.py`, `plot_benchmarks.py`

--- a/README.md
+++ b/README.md
@@ -279,7 +279,8 @@ When `downsampling_method` is set, an OME-NGFF multiscales group is created
 at `store_path/output_key/` (or at `store_path/` if `output_key` is empty),
 containing the full-resolution array at level `0` plus additional downsampled
 levels. The number of levels is determined automatically from the chunk and
-array sizes.
+array sizes. You can cap the pyramid depth with `max_levels` (`0` means no
+limit, which is the default).
 
 ### Organizing data within a Zarr container
 

--- a/include/zarr.types.h
+++ b/include/zarr.types.h
@@ -163,15 +163,17 @@ extern "C"
         ZarrDataType data_type;
         bool multiscale;
         ZarrDownsamplingMethod downsampling_method;
+        uint32_t max_levels; /**< Maximum number of downsampled levels in the
+                                  pyramid. 0 means no limit. */
         const size_t* storage_dimension_order;
     } ZarrArraySettings;
 
     /**
      * @brief Settings for a field of view in a high-content screening (HCS)
      * well.
-     * @note @p array_settings->output_key must be @p NULL, because the path to
+     * @note @p array_settings->output_key must be NULL, because the path to
      * the array is fully specified by @p path. Validation will fail if it is
-     * non-@p NULL
+     * non-NULL.
      */
     typedef struct
     {

--- a/python/acquire-zarr-py.cpp
+++ b/python/acquire-zarr-py.cpp
@@ -37,6 +37,7 @@ struct ArrayLifetimeProps
     bool has_compression{ false };
     ZarrDataType data_type;
     std::optional<ZarrDownsamplingMethod> downsampling_method;
+    uint32_t max_levels{ 0 };
 
     ZarrArraySettings* array_settings()
     {
@@ -78,6 +79,7 @@ struct ArrayLifetimeProps
         array_settings_.multiscale = downsampling_method.has_value();
         array_settings_.downsampling_method =
           downsampling_method.value_or(ZarrDownsamplingMethod_Mean);
+        array_settings_.max_levels = max_levels;
 
         if (!storage_dimension_order.empty()) {
             array_settings_.storage_dimension_order =
@@ -576,6 +578,9 @@ class PyZarrArraySettings
         downsampling_method_ = method;
     }
 
+    uint32_t max_levels() const { return max_levels_; }
+    void set_max_levels(uint32_t levels) { max_levels_ = levels; }
+
     const std::vector<std::string>& storage_dimension_order() const
     {
         return storage_dimension_order_;
@@ -630,6 +635,7 @@ class PyZarrArraySettings
         lt_props.output_key = output_key_;
         lt_props.data_type = data_type_;
         lt_props.downsampling_method = downsampling_method_;
+        lt_props.max_levels = max_levels_;
 
         // compression settings
         if (compression_settings_.has_value()) {
@@ -696,6 +702,7 @@ class PyZarrArraySettings
     std::vector<PyZarrDimensionProperties> dims_;
     ZarrDataType data_type_{ ZarrDataType_uint8 };
     std::optional<ZarrDownsamplingMethod> downsampling_method_{ std::nullopt };
+    uint32_t max_levels_{ 0 };
     std::vector<std::string> storage_dimension_order_;
 };
 
@@ -1583,6 +1590,7 @@ PYBIND11_MODULE(acquire_zarr, m)
                     std::optional<py::list> dimensions,
                     std::optional<py::object> data_type,
                     std::optional<ZarrDownsamplingMethod> downsampling_method,
+                    uint32_t max_levels,
                     std::optional<py::list> storage_dimension_order) {
             PyZarrArraySettings settings;
 
@@ -1621,6 +1629,7 @@ PYBIND11_MODULE(acquire_zarr, m)
             if (downsampling_method) {
                 settings.set_downsampling_method(*downsampling_method);
             }
+            settings.set_max_levels(max_levels);
             if (storage_dimension_order) {
                 auto& order_list = *storage_dimension_order;
                 std::vector<std::string> order_vec(order_list.size());
@@ -1638,6 +1647,7 @@ PYBIND11_MODULE(acquire_zarr, m)
         py::arg("dimensions") = std::nullopt,
         py::arg("data_type") = std::nullopt,
         py::arg("downsampling_method") = std::nullopt,
+        py::arg("max_levels") = 0,
         py::arg("storage_dimension_order") = std::nullopt)
       .def("__repr__",
            [](const PyZarrArraySettings& self) {
@@ -1752,6 +1762,9 @@ PYBIND11_MODULE(acquire_zarr, m)
                   obj.cast<ZarrDownsamplingMethod>());
             }
         })
+      .def_property("max_levels",
+                    &PyZarrArraySettings::max_levels,
+                    &PyZarrArraySettings::set_max_levels)
       .def_property("storage_dimension_order",
                     &PyZarrArraySettings::storage_dimension_order,
                     &PyZarrArraySettings::set_storage_dimension_order);

--- a/python/acquire_zarr/__init__.pyi
+++ b/python/acquire_zarr/__init__.pyi
@@ -70,8 +70,8 @@ class ArraySettings:
       multiscales group is created at ``store_path / output_key`` (or at
       ``store_path`` if ``output_key`` is empty), with the full-resolution
       array at level ``0`` and additional downsampled levels. The number of
-      levels is currently determined automatically from the chunk and array
-      sizes.
+      levels is determined automatically from the chunk and array sizes, and
+      can be capped with ``max_levels``.
 
     Attributes:
       output_key: Path within the Zarr store where this array (or multiscales
@@ -85,6 +85,10 @@ class ArraySettings:
       downsampling_method: Method used for generating optional multiscale levels
         (image pyramid). When set, the array is wrapped in an OME-NGFF
         multiscales group. When None (default), a simple array node is written.
+      max_levels: Maximum number of downsampled pyramid levels to generate when
+        ``downsampling_method`` is set. The number of levels is otherwise
+        determined automatically from the chunk and array sizes. Set to 0
+        (the default) for no limit.
       storage_dimension_order: Order of dimensions for storage, which may different
         from the acquisition order defined in `dimensions`. Must be a list of dimension
         names corresponding to those in `dimensions`.
@@ -102,6 +106,7 @@ class ArraySettings:
     data_type: Union[DataType, numpy.dtype]
     compression: Optional[CompressionSettings]
     downsampling_method: Optional[DownsamplingMethod]
+    max_levels: int
     storage_dimension_order: List[str]
 
     def __init__(self, **kwargs) -> None: ...

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -1170,12 +1170,13 @@ def test_anisotropic_downsampling(settings: StreamSettings, store_path: Path):
     assert "2" in group
     array = group["2"]
     assert array.shape == (250, 500, 500)
-    assert array.chunks == (250, 256, 256)
+    # chunk size is preserved even though z_array (250) < z_chunk (256)
+    assert array.chunks == (256, 256, 256)
 
     assert "3" in group
     array = group["3"]
     assert array.shape == (250, 250, 250)
-    assert array.chunks == (250, 250, 250)
+    assert array.chunks == (256, 256, 256)
 
     assert "4" not in group  # No further downsampling
 
@@ -1768,7 +1769,6 @@ def test_single_2d_image(store_path: Path, request: pytest.FixtureRequest):
 def test_append_throws_on_overflow(
     store_path: Path, request: pytest.FixtureRequest
 ):
-    set_log_level(LogLevel.DEBUG)
     settings = StreamSettings(
         store_path=str(store_path / f"{request.node.name}.zarr"),
         arrays=[
@@ -1820,3 +1820,111 @@ def test_append_throws_on_overflow(
         stream.append(one_more_byte)
 
         assert e
+
+
+def test_multiscale_max_levels(store_path: Path):
+    """max_levels limits the number of downsampled pyramid levels.
+
+    128x128 with 32px chunks produces 2 natural downsampled levels (levels 1
+    and 2).  With max_levels=1 only level 1 should be written.
+    """
+    settings = StreamSettings(
+        store_path=str(store_path / "test.zarr"),
+        arrays=[
+            ArraySettings(
+                dimensions=[
+                    Dimension(
+                        name="t",
+                        kind=DimensionType.TIME,
+                        array_size_px=0,
+                        chunk_size_px=5,
+                        shard_size_chunks=1,
+                    ),
+                    Dimension(
+                        name="y",
+                        kind=DimensionType.SPACE,
+                        array_size_px=128,
+                        chunk_size_px=32,
+                        shard_size_chunks=1,
+                    ),
+                    Dimension(
+                        name="x",
+                        kind=DimensionType.SPACE,
+                        array_size_px=128,
+                        chunk_size_px=32,
+                        shard_size_chunks=1,
+                    ),
+                ],
+                data_type=np.uint16,
+                downsampling_method=DownsamplingMethod.MEAN,
+                max_levels=1,
+            )
+        ],
+    )
+
+    stream = ZarrStream(settings)
+    stream.append(np.zeros((128, 128), dtype=np.uint16))
+    stream.close()
+
+    group = zarr.open(settings.store_path, mode="r")
+    assert "0" in group
+    assert "1" in group
+    assert "2" not in group  # capped by max_levels=1
+
+
+def test_multiscale_chunk_size_preserved(store_path: Path):
+    """Chunk size is preserved at downsampled levels even when smaller than the array.
+
+    Level 1 shrinks y from 48 to 24, which is less than chunk_y=32.  The
+    stored inner chunk shape must remain 32 (not clamped to 24).
+    """
+    settings = StreamSettings(
+        store_path=str(store_path / "test.zarr"),
+        arrays=[
+            ArraySettings(
+                dimensions=[
+                    Dimension(
+                        name="z",
+                        kind=DimensionType.SPACE,
+                        array_size_px=4,
+                        chunk_size_px=4,
+                        shard_size_chunks=1,
+                    ),
+                    Dimension(
+                        name="y",
+                        kind=DimensionType.SPACE,
+                        array_size_px=48,
+                        chunk_size_px=32,
+                        shard_size_chunks=1,
+                    ),
+                    Dimension(
+                        name="x",
+                        kind=DimensionType.SPACE,
+                        array_size_px=64,
+                        chunk_size_px=32,
+                        shard_size_chunks=1,
+                    ),
+                ],
+                data_type=np.uint16,
+                downsampling_method=DownsamplingMethod.MEAN,
+            )
+        ],
+    )
+
+    stream = ZarrStream(settings)
+    stream.append(np.zeros((4, 48, 64), dtype=np.uint16))
+    stream.close()
+
+    group = zarr.open(settings.store_path, mode="r")
+    assert "0" in group
+    assert "1" in group
+    assert "2" not in group  # only one natural XY level
+
+    lod0 = group["0"]
+    assert lod0.shape == (4, 48, 64)
+    assert lod0.chunks == (4, 32, 32)
+
+    lod1 = group["1"]
+    assert lod1.shape == (4, 24, 32)
+    # chunk_size_px=32 must be preserved even though y_array=24 < y_chunk=32
+    assert lod1.chunks == (4, 32, 32)

--- a/src/streaming/array.base.hh
+++ b/src/streaming/array.base.hh
@@ -24,7 +24,8 @@ struct ArrayConfig
                 std::shared_ptr<ArrayDimensions> dimensions,
                 ZarrDataType dtype,
                 std::optional<ZarrDownsamplingMethod> downsampling_method,
-                uint16_t level_of_detail)
+                uint16_t level_of_detail,
+                uint32_t max_levels = 0)
       : store_root(store_root)
       , node_key(group_key)
       , bucket_name(bucket_name)
@@ -33,6 +34,7 @@ struct ArrayConfig
       , dtype(dtype)
       , downsampling_method(downsampling_method)
       , level_of_detail(level_of_detail)
+      , max_levels(max_levels)
     {
         if (downsampling_method.has_value() &&
             *downsampling_method >= ZarrDownsamplingMethodCount) {
@@ -52,6 +54,7 @@ struct ArrayConfig
     ZarrDataType dtype;
     std::optional<ZarrDownsamplingMethod> downsampling_method;
     uint16_t level_of_detail;
+    uint32_t max_levels{ 0 };
 };
 
 enum class WriteResult

--- a/src/streaming/downsampler.cpp
+++ b/src/streaming/downsampler.cpp
@@ -12,8 +12,9 @@ downsample_dimension(const ZarrDimension& dim)
     const uint32_t array_size_px =
       (dim.array_size_px + (dim.array_size_px % 2)) / 2;
 
-    // the smallest this can be is 1
-    const uint32_t chunk_size_px = std::min(dim.chunk_size_px, array_size_px);
+    // chunk size is preserved regardless of array size: a chunk larger than
+    // the array produces a single partial chunk, which is valid in Zarr v3
+    const uint32_t chunk_size_px = dim.chunk_size_px;
 
     // the smallest this can be is also 1
     const uint32_t n_chunks =
@@ -514,12 +515,12 @@ zarr::Downsampler::make_writer_configurations_(
     const auto array_size_x = base_dims->width_dim().array_size_px;
     const auto chunk_size_x = base_dims->width_dim().chunk_size_px;
     const auto n_chunks_x = (array_size_x + chunk_size_x - 1) / chunk_size_x;
-    const auto n_levels_x = n_chunks_x > 1 ? std::bit_width(n_chunks_x - 1) : 0;
+    const uint32_t n_levels_x = n_chunks_x > 1 ? std::bit_width(n_chunks_x - 1) : 0;
 
     const auto array_size_y = base_dims->height_dim().array_size_px;
     const auto chunk_size_y = base_dims->height_dim().chunk_size_px;
     const auto n_chunks_y = (array_size_y + chunk_size_y - 1) / chunk_size_y;
-    const auto n_levels_y = n_chunks_y > 1 ? std::bit_width(n_chunks_y - 1) : 0;
+    const uint32_t n_levels_y = n_chunks_y > 1 ? std::bit_width(n_chunks_y - 1) : 0;
 
     // assume isotropic downsampling, so the number of levels is the same in
     // both
@@ -532,10 +533,14 @@ zarr::Downsampler::make_writer_configurations_(
         const auto chunk_size_z = base_dims->at(ndims - 3).chunk_size_px;
         const auto n_chunks_z =
           (array_size_z + chunk_size_z - 1) / chunk_size_z;
-        const auto n_divs_z =
+        const uint32_t n_divs_z =
           n_chunks_z > 1 ? std::bit_width(n_chunks_z - 1) : 0;
 
         n_levels = std::max(n_levels_xy, n_divs_z);
+    }
+
+    if (config->max_levels > 0) {
+        n_levels = std::min(n_levels, static_cast<uint32_t>(config->max_levels));
     }
 
     for (auto level = 1; level <= n_levels; ++level) {

--- a/src/streaming/multiscale.array.cpp
+++ b/src/streaming/multiscale.array.cpp
@@ -279,7 +279,8 @@ zarr::MultiscaleArray::make_base_array_config_() const
                                          config_->dimensions,
                                          config_->dtype,
                                          std::nullopt,
-                                         0);
+                                         0,
+                                         config_->max_levels);
 }
 
 zarr::WriteResult

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -364,7 +364,8 @@ make_array_config(const ZarrArraySettings* settings,
                                                dimensions,
                                                settings->data_type,
                                                downsampling_method,
-                                               0);
+                                               0,
+                                               settings->max_levels);
 }
 
 [[nodiscard]] bool

--- a/tests/integration/stream-2d-multiscale-to-filesystem.cpp
+++ b/tests/integration/stream-2d-multiscale-to-filesystem.cpp
@@ -220,15 +220,16 @@ verify_array_metadata(const nlohmann::json& meta, int level)
     const auto expected_array_timepoints =
       static_cast<uint32_t>(std::ceil(acquired_frames / array_channels));
 
-    const auto expected_chunk_height =
-      std::min(chunk_height, expected_array_height);
-    const auto expected_chunk_width =
-      std::min(chunk_width, expected_array_width);
+    // Chunk size is preserved regardless of array size (Zarr v3 partial chunks)
+    const auto n_chunks_y =
+      (expected_array_height + chunk_height - 1) / chunk_height;
+    const auto n_chunks_x =
+      (expected_array_width + chunk_width - 1) / chunk_width;
 
     const auto expected_shard_height =
-      std::min(expected_array_height, expected_chunk_height * shard_height);
+      chunk_height * std::min(n_chunks_y, (unsigned int)shard_height);
     const auto expected_shard_width =
-      std::min(expected_array_width, expected_chunk_width * shard_width);
+      chunk_width * std::min(n_chunks_x, (unsigned int)shard_width);
 
     const auto& shape = meta["shape"];
     EXPECT_EQ(size_t, shape.size(), 4);
@@ -258,8 +259,8 @@ verify_array_metadata(const nlohmann::json& meta, int level)
     EXPECT_EQ(size_t, shards.size(), 4);
     EXPECT_EQ(int, shards[0].get<int>(), chunk_timepoints);
     EXPECT_EQ(int, shards[1].get<int>(), chunk_channels);
-    EXPECT_EQ(int, shards[2].get<int>(), expected_chunk_height);
-    EXPECT_EQ(int, shards[3].get<int>(), expected_chunk_width);
+    EXPECT_EQ(int, shards[2].get<int>(), chunk_height);
+    EXPECT_EQ(int, shards[3].get<int>(), chunk_width);
 
     const auto& internal_codecs = sharding_codec["codecs"];
     EXPECT(internal_codecs.size() == 2,
@@ -297,16 +298,11 @@ verify_file_data(int level)
     const auto expected_array_timepoints =
       static_cast<uint32_t>(std::ceil(acquired_frames / array_channels));
 
-    const auto expected_chunk_height =
-      std::min(chunk_height, expected_array_height);
-    const auto expected_chunk_width =
-      std::min(chunk_width, expected_array_width);
-
+    // Chunk size is preserved regardless of array size (Zarr v3 partial chunks)
     const auto expected_chunks_in_x =
-      (expected_array_width + expected_chunk_width - 1) / expected_chunk_width;
+      (expected_array_width + chunk_width - 1) / chunk_width;
     const auto expected_chunks_in_y =
-      (expected_array_height + expected_chunk_height - 1) /
-      expected_chunk_height;
+      (expected_array_height + chunk_height - 1) / chunk_height;
     const auto expected_chunks_in_t =
       (expected_array_timepoints + chunk_timepoints - 1) / chunk_timepoints;
 
@@ -317,9 +313,8 @@ verify_file_data(int level)
     const unsigned int expected_shards_in_t =
       (expected_chunks_in_t + shard_timepoints - 1) / shard_timepoints;
 
-    const auto expected_chunk_size = expected_chunk_width *
-                                     expected_chunk_height * chunk_channels *
-                                     chunk_timepoints * nbytes_px;
+    const auto expected_chunk_size =
+      chunk_width * chunk_height * chunk_channels * chunk_timepoints * nbytes_px;
 
     const auto index_size = chunks_per_shard *
                             sizeof(uint64_t) * // indices are 64 bits

--- a/tests/integration/stream-3d-multiscale-to-filesystem.cpp
+++ b/tests/integration/stream-3d-multiscale-to-filesystem.cpp
@@ -254,19 +254,20 @@ verify_array_metadata(const nlohmann::json& meta, int level)
     const auto expected_array_timepoints = static_cast<uint32_t>(
       std::ceil(acquired_frames / (array_channels * expected_array_planes)));
 
-    const auto expected_chunk_planes =
-      std::min(chunk_planes, expected_array_planes);
-    const auto expected_chunk_height =
-      std::min(chunk_height, expected_array_height);
-    const auto expected_chunk_width =
-      std::min(chunk_width, expected_array_width);
+    // Chunk size is preserved regardless of array size (Zarr v3 partial chunks)
+    const auto n_chunks_z =
+      (expected_array_planes + chunk_planes - 1) / chunk_planes;
+    const auto n_chunks_y =
+      (expected_array_height + chunk_height - 1) / chunk_height;
+    const auto n_chunks_x =
+      (expected_array_width + chunk_width - 1) / chunk_width;
 
     const auto expected_shard_planes =
-      std::min(expected_array_planes, expected_chunk_planes * shard_planes);
+      chunk_planes * std::min(n_chunks_z, (unsigned int)shard_planes);
     const auto expected_shard_height =
-      std::min(expected_array_height, expected_chunk_height * shard_height);
+      chunk_height * std::min(n_chunks_y, (unsigned int)shard_height);
     const auto expected_shard_width =
-      std::min(expected_array_width, expected_chunk_width * shard_width);
+      chunk_width * std::min(n_chunks_x, (unsigned int)shard_width);
 
     const auto& shape = meta["shape"];
     EXPECT_EQ(size_t, shape.size(), 5);
@@ -298,9 +299,9 @@ verify_array_metadata(const nlohmann::json& meta, int level)
     EXPECT_EQ(size_t, shards.size(), 5);
     EXPECT_EQ(int, shards[0].get<int>(), chunk_timepoints);
     EXPECT_EQ(int, shards[1].get<int>(), chunk_channels);
-    EXPECT_EQ(int, shards[2].get<int>(), expected_chunk_planes);
-    EXPECT_EQ(int, shards[3].get<int>(), expected_chunk_height);
-    EXPECT_EQ(int, shards[4].get<int>(), expected_chunk_width);
+    EXPECT_EQ(int, shards[2].get<int>(), chunk_planes);
+    EXPECT_EQ(int, shards[3].get<int>(), chunk_height);
+    EXPECT_EQ(int, shards[4].get<int>(), chunk_width);
 
     const auto& internal_codecs = sharding_codec["codecs"];
     EXPECT(internal_codecs.size() == 2,
@@ -340,21 +341,13 @@ verify_file_data(int level)
     const auto expected_array_timepoints = static_cast<uint32_t>(
       std::ceil(acquired_frames / (array_channels * expected_array_planes)));
 
-    const auto expected_chunk_planes =
-      std::min(chunk_planes, expected_array_planes);
-    const auto expected_chunk_height =
-      std::min(chunk_height, expected_array_height);
-    const auto expected_chunk_width =
-      std::min(chunk_width, expected_array_width);
-
+    // Chunk size is preserved regardless of array size (Zarr v3 partial chunks)
     const auto expected_chunks_in_x =
-      (expected_array_width + expected_chunk_width - 1) / expected_chunk_width;
+      (expected_array_width + chunk_width - 1) / chunk_width;
     const auto expected_chunks_in_y =
-      (expected_array_height + expected_chunk_height - 1) /
-      expected_chunk_height;
+      (expected_array_height + chunk_height - 1) / chunk_height;
     const auto expected_chunks_in_z =
-      (expected_array_planes + expected_chunk_planes - 1) /
-      expected_chunk_planes;
+      (expected_array_planes + chunk_planes - 1) / chunk_planes;
     const auto expected_chunks_in_t =
       (expected_array_timepoints + chunk_timepoints - 1) / chunk_timepoints;
 
@@ -368,8 +361,8 @@ verify_file_data(int level)
       (expected_chunks_in_t + shard_timepoints - 1) / shard_timepoints;
 
     const auto expected_chunk_size =
-      expected_chunk_width * expected_chunk_height * expected_chunk_planes *
-      chunk_channels * chunk_timepoints * nbytes_px;
+      chunk_width * chunk_height * chunk_planes * chunk_channels *
+      chunk_timepoints * nbytes_px;
 
     const auto index_size = chunks_per_shard *
                             sizeof(uint64_t) * // indices are 64 bits

--- a/tests/integration/stream-multiple-arrays-to-filesystem.cpp
+++ b/tests/integration/stream-multiple-arrays-to-filesystem.cpp
@@ -23,7 +23,6 @@ setup()
         .max_threads = 0, // use all available threads
         .overwrite = true,
     };
-    ZarrDimensionProperties* dim;
 
     CHECK_OK(ZarrStreamSettings_create_arrays(&settings, 3));
 
@@ -36,19 +35,11 @@ setup()
 
     // configure labels array dimensions
     CHECK_OK(ZarrArraySettings_create_dimension_array(settings.arrays, 5));
-    dim = settings.arrays[0].dimensions;
-    *dim = DIM("t", ZarrDimensionType_Time, 0, 3, 1, nullptr, 1.0);
-
-    dim = settings.arrays[0].dimensions + 1;
-    *dim = DIM("c", ZarrDimensionType_Channel, 3, 1, 3, nullptr, 1.0);
-
-    dim = settings.arrays[0].dimensions + 2;
-    *dim = DIM("z", ZarrDimensionType_Space, 4, 2, 2, "millimeter", 1.4);
-
-    dim = settings.arrays[0].dimensions + 3;
-    *dim = DIM("y", ZarrDimensionType_Space, 48, 16, 3, "micrometer", 0.9);
-
-    dim = settings.arrays[0].dimensions + 4;
+    ZarrDimensionProperties* dim = settings.arrays[0].dimensions;
+    *dim++ = DIM("t", ZarrDimensionType_Time, 0, 3, 1, nullptr, 1.0);
+    *dim++ = DIM("c", ZarrDimensionType_Channel, 3, 1, 3, nullptr, 1.0);
+    *dim++ = DIM("z", ZarrDimensionType_Space, 4, 2, 2, "millimeter", 1.4);
+    *dim++ = DIM("y", ZarrDimensionType_Space, 48, 16, 3, "micrometer", 0.9);
     *dim = DIM("x", ZarrDimensionType_Space, 64, 16, 2, "micrometer", 0.9);
 
     // create the first array
@@ -62,15 +53,9 @@ setup()
     // configure first array dimensions
     CHECK_OK(ZarrArraySettings_create_dimension_array(settings.arrays + 1, 4));
     dim = settings.arrays[1].dimensions;
-    *dim = DIM("t", ZarrDimensionType_Time, 0, 5, 1, nullptr, 1.0);
-
-    dim = settings.arrays[1].dimensions + 1;
-    *dim = DIM("z", ZarrDimensionType_Space, 6, 3, 2, "millimeter", 1.0);
-
-    dim = settings.arrays[1].dimensions + 2;
-    *dim = DIM("y", ZarrDimensionType_Space, 48, 16, 1, "micrometer", 1.0);
-
-    dim = settings.arrays[1].dimensions + 3;
+    *dim++ = DIM("t", ZarrDimensionType_Time, 0, 5, 1, nullptr, 1.0);
+    *dim++ = DIM("z", ZarrDimensionType_Space, 6, 3, 2, "millimeter", 1.0);
+    *dim++ = DIM("y", ZarrDimensionType_Space, 48, 16, 1, "micrometer", 1.0);
     *dim = DIM("x", ZarrDimensionType_Space, 64, 16, 1, "micrometer", 1.0);
 
     // create the second array
@@ -90,12 +75,8 @@ setup()
     // configure second array dimensions
     CHECK_OK(ZarrArraySettings_create_dimension_array(settings.arrays + 2, 3));
     dim = settings.arrays[2].dimensions;
-    *dim = DIM("z", ZarrDimensionType_Space, 0, 3, 1, nullptr, 1.0);
-
-    dim = settings.arrays[2].dimensions + 1;
-    *dim = DIM("y", ZarrDimensionType_Space, 48, 16, 1, "micrometer", 1.0);
-
-    dim = settings.arrays[2].dimensions + 2;
+    *dim++ = DIM("z", ZarrDimensionType_Space, 0, 3, 1, nullptr, 1.0);
+    *dim++ = DIM("y", ZarrDimensionType_Space, 48, 16, 1, "micrometer", 1.0);
     *dim = DIM("x", ZarrDimensionType_Space, 64, 16, 1, "micrometer", 1.0);
 
     auto* stream = ZarrStream_create(&settings);
@@ -152,7 +133,9 @@ verify_shape(const nlohmann::json& metadata,
     EXPECT_EQ(size_t, shape.size(), expected_shape.size());
 
     for (size_t i = 0; i < expected_shape.size(); ++i) {
-        EXPECT_EQ(int, shape[i].get<int>(), expected_shape[i]);
+        const auto& expected = expected_shape[i];
+        const auto& actual = shape[i].get<int>();
+        EXPECT_EQ(int, actual, expected);
     }
 }
 
@@ -804,9 +787,11 @@ verify_array1_lod2_metadata(const nlohmann::json& metadata)
 
     verify_shape(metadata, { 10, 3, 12, 16 });
     verify_dimension_names(metadata, { "t", "z", "y", "x" });
-    verify_chunk_grid(metadata, { 5, 3, 12, 16 });
+
+    // chunk size is larger than the array size
+    verify_chunk_grid(metadata, { 5, 3, 16, 16 });
     verify_chunk_key_encoding(metadata);
-    verify_codecs(metadata, { 5, 3, 12, 16 }, false);
+    verify_codecs(metadata, { 5, 3, 16, 16 }, false);
 }
 
 void

--- a/tests/unit-tests/downsampler.cpp
+++ b/tests/unit-tests/downsampler.cpp
@@ -369,7 +369,7 @@ test_anisotropic_writer_configurations()
 
     // Check that spatial dimensions are downsampled
     {
-        const auto level = 1;
+        constexpr auto level = 1;
         const auto lvl_config = configs.at(level);
         const auto& lvl_dims = lvl_config->dimensions;
 
@@ -384,7 +384,7 @@ test_anisotropic_writer_configurations()
     }
 
     {
-        const auto level = 2;
+        constexpr auto level = 2;
         const auto lvl_config = configs.at(level);
         const auto& lvl_dims = lvl_config->dimensions;
 
@@ -392,22 +392,22 @@ test_anisotropic_writer_configurations()
         EXPECT_EQ(uint32_t, lvl_dims->at(2).chunk_size_px, 128);
 
         EXPECT_EQ(uint32_t, lvl_dims->at(3).array_size_px, 500);
-        EXPECT_EQ(uint32_t, lvl_dims->at(3).chunk_size_px, 500);
+        EXPECT_EQ(uint32_t, lvl_dims->at(3).chunk_size_px, 512);
 
         EXPECT_EQ(uint32_t, lvl_dims->at(4).array_size_px, 500);
         EXPECT_EQ(uint32_t, lvl_dims->at(4).chunk_size_px, 256);
     }
 
     {
-        const auto level = 3;
+        constexpr auto level = 3;
         const auto lvl_config = configs.at(level);
         const auto& lvl_dims = lvl_config->dimensions;
 
         EXPECT_EQ(uint32_t, lvl_dims->at(2).array_size_px, 125);
-        EXPECT_EQ(uint32_t, lvl_dims->at(2).chunk_size_px, 125);
+        EXPECT_EQ(uint32_t, lvl_dims->at(2).chunk_size_px, 128);
 
         EXPECT_EQ(uint32_t, lvl_dims->at(3).array_size_px, 500);
-        EXPECT_EQ(uint32_t, lvl_dims->at(3).chunk_size_px, 500);
+        EXPECT_EQ(uint32_t, lvl_dims->at(3).chunk_size_px, 512);
 
         EXPECT_EQ(uint32_t, lvl_dims->at(4).array_size_px, 500);
         EXPECT_EQ(uint32_t, lvl_dims->at(4).chunk_size_px, 256);
@@ -753,6 +753,62 @@ test_pattern_downsampling()
         });
     }
 }
+void
+test_max_levels()
+{
+    // Without max_levels, these dimensions would produce 3 downsampled levels
+    // (levels 1, 2, 3) plus the base (level 0) = 4 total.
+    std::vector<ZarrDimension> dimensions = {
+        { "t", ZarrDimensionType_Time, 100, 10, 1 },
+        { "y", ZarrDimensionType_Space, 512, 64, 1 },
+        { "x", ZarrDimensionType_Space, 512, 64, 1 },
+    };
+
+    auto dims = std::make_shared<ArrayDimensions>(
+      std::vector<ZarrDimension>(dimensions), ZarrDataType_uint16);
+
+    auto config =
+      std::make_shared<zarr::ArrayConfig>("",
+                                          "/0",
+                                          std::nullopt,
+                                          std::nullopt,
+                                          dims,
+                                          ZarrDataType_uint16,
+                                          ZarrDownsamplingMethod_Mean,
+                                          0,
+                                          2 /* max_levels */);
+
+    zarr::Downsampler downsampler(config, ZarrDownsamplingMethod_Mean);
+    const auto& configs = downsampler.writer_configurations();
+
+    EXPECT(configs.size() == 3,
+           "Expected 3 writer configurations (levels 0-2), got ",
+           configs.size());
+
+    EXPECT(configs.count(0) > 0, "Level 0 configuration missing");
+    EXPECT(configs.count(1) > 0, "Level 1 configuration missing");
+    EXPECT(configs.count(2) > 0, "Level 2 configuration missing");
+    EXPECT(configs.count(3) == 0, "Level 3 should not exist with max_levels=2");
+
+    // max_levels=0 means no limit — verify all levels are produced
+    config = std::make_shared<zarr::ArrayConfig>("",
+                                                 "/0",
+                                                 std::nullopt,
+                                                 std::nullopt,
+                                                 dims,
+                                                 ZarrDataType_uint16,
+                                                 ZarrDownsamplingMethod_Mean,
+                                                 0,
+                                                 0 /* max_levels = no limit */);
+
+    zarr::Downsampler downsampler2(config, ZarrDownsamplingMethod_Mean);
+    const auto& configs2 = downsampler2.writer_configurations();
+
+    EXPECT(configs2.size() > 3,
+           "Expected more than 3 writer configurations without max_levels limit, "
+           "got ",
+           configs2.size());
+}
 } // namespace zarr::test
 
 int
@@ -770,6 +826,7 @@ main()
         test_min_max_downsampling();
         test_3d_min_max_downsampling();
         test_pattern_downsampling();
+        test_max_levels();
 
         retval = 0;
     } catch (const std::exception& e) {


### PR DESCRIPTION
Fixes #224.

## Summary

- Adds `max_levels` field to `ZarrArraySettings` (C) and `ArraySettings` (Python) to cap the number of downsampled pyramid levels generated; `0` means no limit (default), preserving existing behavior
- Changes chunk size behavior at downsampled levels: chunk sizes are now preserved rather than clamped to the array size, so a chunk larger than the array produces a single partial chunk (valid in Zarr v3)
- Updates all affected C++ integration tests and Python tests to reflect the new chunk-size semantics
- Adds `test_multiscale_max_levels` and `test_multiscale_chunk_size_preserved` Python tests

## Test plan

- [ ] `just test-cpp` — unit tests (`test_max_levels`, `test_anisotropic_writer_configurations`) and integration tests (2D and 3D multiscale) pass
- [ ] `just test` — Python tests including `test_multiscale_max_levels`, `test_multiscale_chunk_size_preserved`, and `test_anisotropic_downsampling` pass
- [ ] Verify that passing `max_levels=0` (default) produces the same number of levels as before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)