### PR TITLE
Fix LOD1 pixel corruption for odd Z with downsampling (#226)

### DIFF
--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -1039,6 +1039,87 @@ def test_3d_multiscale_stream(store_path: Path, method: DownsamplingMethod):
         np.testing.assert_array_equal(actual, expected)
 
 
+# see acquire-project/acquire-zarr#226
+def test_odd_z_multi_channel_no_lod_bleed(store_path: Path):
+    T, C, Z, Y, X = 2, 2, 3, 8, 8
+    dtype = np.uint16
+
+    settings = StreamSettings(
+        store_path=str(store_path / "test.zarr"),
+        overwrite=True,
+        arrays=[
+            ArraySettings(
+                output_key="image",
+                data_type=dtype,
+                dimensions=[
+                    Dimension(
+                        name="t",
+                        kind=DimensionType.TIME,
+                        array_size_px=T,
+                        chunk_size_px=1,
+                        shard_size_chunks=T,
+                    ),
+                    Dimension(
+                        name="c",
+                        kind=DimensionType.CHANNEL,
+                        array_size_px=C,
+                        chunk_size_px=1,
+                        shard_size_chunks=C,
+                    ),
+                    Dimension(
+                        name="z",
+                        kind=DimensionType.SPACE,
+                        array_size_px=Z,
+                        chunk_size_px=1,
+                        shard_size_chunks=Z,
+                    ),
+                    Dimension(
+                        name="y",
+                        kind=DimensionType.SPACE,
+                        array_size_px=Y,
+                        chunk_size_px=Y,
+                        shard_size_chunks=1,
+                    ),
+                    Dimension(
+                        name="x",
+                        kind=DimensionType.SPACE,
+                        array_size_px=X,
+                        chunk_size_px=X,
+                        shard_size_chunks=1,
+                    ),
+                ],
+                downsampling_method=DownsamplingMethod.MEAN,
+            )
+        ],
+    )
+
+    stream = ZarrStream(settings)
+    channel_values = [100, 200]
+    for t in range(T):
+        for c in range(C):
+            block = np.full((1, 1, Z, Y, X), channel_values[c], dtype=dtype)
+            stream.append(block, key="image")
+    stream.close()
+
+    group = zarr.open(settings.store_path, mode="r")["image"]
+
+    full_res = np.asarray(group["0"])
+    assert full_res.shape == (T, C, Z, Y, X)
+    for t in range(T):
+        for c in range(C):
+            assert np.all(full_res[t, c] == channel_values[c])
+
+    lod1 = np.asarray(group["1"])
+    assert lod1.shape == (T, C, (Z + 1) // 2, Y, X)
+    for t in range(T):
+        for c in range(C):
+            assert np.all(lod1[t, c] == channel_values[c]), (
+                f"LOD1 bleed at t={t}, c={c}: "
+                f"got values {np.unique(lod1[t, c])}, "
+                f"expected {channel_values[c]}"
+            )
+
+
 @pytest.mark.parametrize(
     ("output_key", "downsampling_method"),
     [

--- a/src/streaming/downsampler.cpp
+++ b/src/streaming/downsampler.cpp
@@ -309,6 +309,7 @@ zarr::Downsampler::add_frame(std::vector<uint8_t>& frame)
     const auto& base_dims = writer_configurations_[0]->dimensions;
     size_t frame_width = base_dims->width_dim().array_size_px;
     size_t frame_height = base_dims->height_dim().array_size_px;
+    ++level_frame_count_.at(0);
 
     ByteVector current_frame(frame.begin(), frame.end());
     ByteVector next_level_frame;

--- a/tests/unit-tests/downsampler-odd-z.cpp
+++ b/tests/unit-tests/downsampler-odd-z.cpp
@@ -16,6 +16,75 @@ create_test_image(size_t width, size_t height, T value = 100)
     return std::move(data);
 }
 
+// see acquire-project/acquire-zarr#226
+void
+test_odd_z_multi_tc_no_bleed()
+{
+    auto dims = std::make_shared<ArrayDimensions>(
+      std::vector<ZarrDimension>{
+        { "t", ZarrDimensionType_Time, 0, 1, 1 },
+        { "c", ZarrDimensionType_Channel, 2, 1, 2 },
+        { "z", ZarrDimensionType_Space, 3, 1, 1 },
+        { "y", ZarrDimensionType_Space, 8, 4, 1 },
+        { "x", ZarrDimensionType_Space, 8, 4, 1 },
+      },
+      ZarrDataType_uint16);
+    auto config =
+      std::make_shared<zarr::ArrayConfig>("",
+                                          "/0",
+                                          std::nullopt,
+                                          std::nullopt,
+                                          dims,
+                                          ZarrDataType_uint16,
+                                          ZarrDownsamplingMethod_Mean,
+                                          0);
+
+    zarr::Downsampler downsampler(config, ZarrDownsamplingMethod_Mean);
+
+    const std::vector<uint16_t> channel_values = { 100, 200 };
+    constexpr uint32_t T = 2;
+    constexpr uint32_t Z = 3;
+
+    std::vector<uint16_t> observed_values;
+    for (uint32_t t = 0; t < T; ++t) {
+        for (uint16_t value : channel_values) {
+            for (uint32_t z = 0; z < Z; ++z) {
+                auto frame = create_test_image<uint16_t>(8, 8, value);
+                downsampler.add_frame(frame);
+
+                std::vector<uint8_t> downsampled;
+                if (downsampler.take_frame(1, downsampled)) {
+                    const auto* typed =
+                      reinterpret_cast<const uint16_t*>(downsampled.data());
+                    const size_t n_pixels =
+                      downsampled.size() / sizeof(uint16_t);
+                    // Frame is uniform → every pixel matches the first.
+                    for (size_t i = 0; i < n_pixels; ++i) {
+                        EXPECT_EQ(uint16_t, typed[i], typed[0]);
+                    }
+                    observed_values.push_back(typed[0]);
+                }
+            }
+        }
+    }
+
+    EXPECT_EQ(size_t, observed_values.size(), 8);
+
+    const std::vector<uint16_t> expected = {
+        100, 100, // T=0, C=0
+        200, 200, // T=0, C=1
+        100, 100, // T=1, C=0
+        200, 200, // T=1, C=1
+    };
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(uint16_t, observed_values[i], expected[i]);
+    }
+
+    std::vector<uint8_t> leftover;
+    EXPECT(!downsampler.take_frame(1, leftover),
+           "Unexpected leftover level-1 frame after all inputs consumed");
+}
+
 void
 check_downsample(zarr::Downsampler& downsampler, uint8_t frame_value)
 {
@@ -99,6 +168,8 @@ main()
         check_downsample(downsampler, 63);
         check_downsample(downsampler, 127);
         check_downsample(downsampler, 255);
+
+        test_odd_z_multi_tc_no_bleed();
 
         return 0;
     } catch (const std::exception& e) {


### PR DESCRIPTION
Fixes #226.

- Diagnosis: `level_frame_count_[0]` was initialized in the `Downsampler` constructor but never incremented; only emissions at levels >= 1 advanced their respective counters. The odd-Z guard `level_frame_count_[level-1] % prev_planes == 0` therefore evaluated true on every input at level 1, which forced `average_this_frame = false`, bypassing Z-averaging and emitting one LOD1 plane per input — overflowing the LOD1 array bounds on the first multi-(T,C) input and producing the cross-channel bleed and "Unable to write" stderr errors described in the issue.
- Fix: increment `level_frame_count_[0]` at the top of `Downsampler::add_frame` so it tracks incoming Z-planes. The guard now fires only at the unpaired last Z-plane of each (T,C) frame (counts `Z`, `2Z`, `3Z`, …), restoring correct pair-averaging within each (T,C) and a clean reset at frame boundaries.
- Adds a C++ unit test (`test_odd_z_multi_tc_no_bleed` in `tests/unit-tests/downsampler-odd-z.cpp`) and a Python regression test (`test_odd_z_multi_channel_no_lod_bleed` in `python/tests/test_stream.py`), both modelled on the issue's minimal reproducer (T=2, C=2, Z=3, channel-distinct values).