### PR TITLE
Streaming write-path performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Bound the frame queue to 256 MiB; `append()` now applies backpressure instead of buffering unboundedly, cutting
+  peak memory ~3x at the cost of higher tail latency under sustained pressure
+- Copy frames directly into chunk buffers, removing an intermediate copy (~1.3-1.9x write throughput on filesystem)
+- Windows: reuse the per-handle `OVERLAPPED` event and drop the per-close `FlushFileBuffers`
+- Enable AVX2 and LTO for the streaming library
+
 ## [0.8.0] - [2026-05-29](https://github.com/acquire-project/acquire-zarr/compare/v0.7.0...v0.8.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bound the frame queue to 256 MiB; `append()` now applies backpressure instead of buffering unboundedly, cutting
-  peak memory ~3x at the cost of higher tail latency under sustained pressure
-- Copy frames directly into chunk buffers, removing an intermediate copy (~1.3-1.9x write throughput on filesystem)
-- Windows: reuse the per-handle `OVERLAPPED` event and drop the per-close `FlushFileBuffers`
-- Enable AVX2 and LTO for the streaming library
+  peak memory ~3x at the cost of higher tail latency under sustained pressure (#230)
+- Copy frames directly into chunk buffers, removing an intermediate copy (~1.3-1.9x write throughput on filesystem) (#230)
+- Windows: reuse the per-handle `OVERLAPPED` event and drop the per-close `FlushFileBuffers` (#230)
+- Enable AVX2 and LTO for the streaming library (#230)
 
 ## [0.8.0] - [2026-05-29](https://github.com/acquire-project/acquire-zarr/compare/v0.7.0...v0.8.0)
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import glob
 import os
 from pathlib import Path
 import subprocess
+import sys
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
 
@@ -33,8 +34,19 @@ class CMakeBuild(build_ext):
             "-DBUILD_TESTING=OFF",
         ]
 
-        extra_args = os.environ.get("CMAKE_ARGS", "").split()
-        cmake_args += [arg for arg in extra_args if arg]  # Filter out empty strings
+        extra_args = [
+            arg for arg in os.environ.get("CMAKE_ARGS", "").split() if arg
+        ]
+        cmake_args += extra_args
+
+        # macOS: <filesystem> requires a deployment target of 10.15+, but
+        # setuptools defaults MACOSX_DEPLOYMENT_TARGET to the Python build's
+        # value (often 10.9). Pin a modern target unless the caller overrides.
+        if sys.platform == "darwin" and not any(
+            "CMAKE_OSX_DEPLOYMENT_TARGET" in arg for arg in cmake_args
+        ):
+            target = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "11.0")
+            cmake_args.append(f"-DCMAKE_OSX_DEPLOYMENT_TARGET={target}")
 
         if self.compiler.compiler_type == "msvc":
             cmake_args.append("-DVCPKG_TARGET_TRIPLET=x64-windows-static")

--- a/src/streaming/CMakeLists.txt
+++ b/src/streaming/CMakeLists.txt
@@ -77,6 +77,20 @@ set_target_properties(${tgt} PROPERTIES
         POSITION_INDEPENDENT_CODE ON
 )
 
+# Performance: AVX2 baseline for the streaming hot path (tiling/downsample
+# loops). NB: requires an AVX2-capable CPU at runtime; gate for distribution
+# on pre-AVX2 targets. Blosc has its own runtime SIMD dispatch.
+target_enable_simd(${tgt})
+
+# Link-time optimization for Release builds of the hot-path library.
+include(CheckIPOSupported)
+check_ipo_supported(RESULT ipo_supported OUTPUT ipo_error LANGUAGES CXX)
+if (ipo_supported)
+    set_target_properties(${tgt} PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+else ()
+    message(STATUS "IPO/LTO not supported, skipping: ${ipo_error}")
+endif ()
+
 install(TARGETS ${tgt}
         EXPORT acquire-zarrTargets
         LIBRARY DESTINATION lib

--- a/src/streaming/array.cpp
+++ b/src/streaming/array.cpp
@@ -533,14 +533,12 @@ zarr::Array::write_frame_to_chunks_(std::vector<uint8_t>& frame)
     size_t bytes_written = 0;
     const auto n_tiles = n_tiles_x * n_tiles_y;
 
-    std::vector<std::vector<uint8_t>> tiles(n_tiles);
-    for (auto& tile : tiles) {
-        tile.resize(bytes_per_tile_row * tile_rows, 0);
-    }
+    const auto* data_ptr = frame.data();
+    const auto data_size = frame.size();
+    const auto src_row_stride = static_cast<size_t>(frame_cols) * bytes_per_px;
 
 #pragma omp parallel for reduction(+ : bytes_written)
     for (auto tile_idx = 0; tile_idx < n_tiles; ++tile_idx) {
-        auto& tile = tiles[tile_idx];
         auto& chunk = chunks_[tile_idx + group_offset];
         {
             std::unique_lock lock(chunk_mutexes_[tile_idx + group_offset]);
@@ -549,50 +547,40 @@ zarr::Array::write_frame_to_chunks_(std::vector<uint8_t>& frame)
             }
         }
 
-        const auto* data_ptr = frame.data();
-        const auto data_size = frame.size();
-
-        const auto tile_start = tile.data();
-
         const auto tile_idx_y = tile_idx / n_tiles_x;
         const auto tile_idx_x = tile_idx % n_tiles_x;
 
-        size_t tile_pos = 0;
-
-        for (auto k = 0; k < tile_rows; ++k) {
-            const auto frame_row = tile_idx_y * tile_rows + k;
-            if (frame_row < frame_rows) {
-                const auto frame_col = tile_idx_x * tile_cols;
-
-                const auto region_width =
-                  std::min(frame_col + tile_cols, frame_cols) - frame_col;
-
-                const auto region_start =
-                  bytes_per_px * (frame_row * frame_cols + frame_col);
-                const auto nbytes = region_width * bytes_per_px;
-
-                // copy region
-                EXPECT(region_start + nbytes <= data_size,
-                       "Buffer overflow in framme. Region start: ",
-                       region_start,
-                       " nbytes: ",
-                       nbytes,
-                       " data size: ",
-                       data_size);
-                EXPECT(tile_pos + nbytes <= tile.size(),
-                       "Buffer overflow in tile. Tile pos: ",
-                       tile_pos,
-                       " nbytes: ",
-                       nbytes,
-                       " bytes per tile: ",
-                       tile.size());
-                memcpy(tile_start + tile_pos, data_ptr + region_start, nbytes);
-                bytes_written += nbytes;
-            }
-            tile_pos += bytes_per_tile_row;
+        const uint32_t frame_row0 = tile_idx_y * tile_rows;
+        if (frame_row0 >= frame_rows) {
+            continue; // tile lies entirely below the frame: no data to copy
         }
+        const uint32_t n_rows =
+          std::min<uint32_t>(tile_rows, frame_rows - frame_row0);
 
-        chunk->write_tile(chunk_offset, std::move(tile));
+        const auto frame_col = tile_idx_x * tile_cols;
+        const auto region_width =
+          std::min(frame_col + tile_cols, frame_cols) - frame_col;
+        const auto copy_nbytes = static_cast<size_t>(region_width) * bytes_per_px;
+
+        const auto region_start =
+          bytes_per_px * (static_cast<size_t>(frame_row0) * frame_cols + frame_col);
+        EXPECT(region_start + static_cast<size_t>(n_rows - 1) * src_row_stride +
+                   copy_nbytes <=
+                 data_size,
+               "Buffer overflow in frame. region_start: ",
+               region_start,
+               ", data size: ",
+               data_size);
+
+        // Copy frame rows straight into the chunk buffer; no intermediate
+        // per-tile allocation, zero-fill, or second memcpy.
+        chunk->write_tile_rows(chunk_offset,
+                               data_ptr + region_start,
+                               src_row_stride,
+                               copy_nbytes,
+                               bytes_per_tile_row,
+                               n_rows);
+        bytes_written += copy_nbytes * n_rows;
     }
 
     return bytes_written;

--- a/src/streaming/chunk.cpp
+++ b/src/streaming/chunk.cpp
@@ -15,28 +15,46 @@ zarr::Chunk::Chunk(size_t size_bytes, size_t bytes_per_px)
 }
 
 void
-zarr::Chunk::write_tile(uint64_t internal_offset, std::vector<uint8_t>&& tile)
+zarr::Chunk::write_tile_rows(uint64_t internal_offset,
+                             const uint8_t* src,
+                             size_t src_row_stride,
+                             size_t copy_nbytes,
+                             size_t dst_row_stride,
+                             uint32_t n_rows)
 {
-    EXPECT(internal_offset + tile.size() <= buffer_.size(),
+    if (n_rows == 0 || copy_nbytes == 0) {
+        return;
+    }
+
+    const uint64_t span =
+      static_cast<uint64_t>(n_rows - 1) * dst_row_stride + copy_nbytes;
+    EXPECT(internal_offset + span <= buffer_.size(),
            "Cannot write ",
-           tile.size(),
+           span,
            " bytes at offset ",
            internal_offset,
            " to buffer of size ",
            buffer_.size(),
            ".");
 
-    if (!has_data_.load(std::memory_order_relaxed)) {
-        const bool any_nonzero =
-          std::ranges::any_of(tile, [](uint8_t b) { return b != 0; });
+    std::unique_lock lock(mutex_);
+    uint8_t* dst = buffer_.data() + internal_offset;
+    bool any_nonzero = has_data_.load(std::memory_order_relaxed);
+
+    for (uint32_t r = 0; r < n_rows; ++r) {
+        const uint8_t* s = src + static_cast<size_t>(r) * src_row_stride;
+        memcpy(dst + static_cast<size_t>(r) * dst_row_stride, s, copy_nbytes);
+        // Detect the chunk's first nonzero data to preserve the all-zero-chunk
+        // skip optimization; stop scanning once we know it has data.
         if (!any_nonzero) {
-            return;
+            any_nonzero = std::any_of(
+              s, s + copy_nbytes, [](uint8_t b) { return b != 0; });
         }
     }
 
-    std::unique_lock lock(mutex_);
-    has_data_.store(true, std::memory_order_relaxed);
-    memcpy(buffer_.data() + internal_offset, tile.data(), tile.size());
+    if (any_nonzero) {
+        has_data_.store(true, std::memory_order_relaxed);
+    }
 }
 
 const std::vector<uint8_t>&

--- a/src/streaming/chunk.hh
+++ b/src/streaming/chunk.hh
@@ -14,8 +14,6 @@ class Chunk
     Chunk(size_t size_bytes, size_t bytes_per_px);
     ~Chunk() = default;
 
-    void write_tile(uint64_t internal_offset, std::vector<uint8_t>&& tile);
-
     // Copy a frame's tile directly into the chunk buffer, row by row, without
     // an intermediate per-tile heap buffer. Row r of `copy_nbytes` bytes is
     // read from `src + r*src_row_stride` and written at

--- a/src/streaming/chunk.hh
+++ b/src/streaming/chunk.hh
@@ -16,6 +16,19 @@ class Chunk
 
     void write_tile(uint64_t internal_offset, std::vector<uint8_t>&& tile);
 
+    // Copy a frame's tile directly into the chunk buffer, row by row, without
+    // an intermediate per-tile heap buffer. Row r of `copy_nbytes` bytes is
+    // read from `src + r*src_row_stride` and written at
+    // `internal_offset + r*dst_row_stride`. Bytes in each destination row past
+    // copy_nbytes (edge-tile padding) are left untouched (zero-initialized).
+    // Sets has_data if any copied byte is nonzero.
+    void write_tile_rows(uint64_t internal_offset,
+                         const uint8_t* src,
+                         size_t src_row_stride,
+                         size_t copy_nbytes,
+                         size_t dst_row_stride,
+                         uint32_t n_rows);
+
     const std::vector<uint8_t>& buffer();
 
     bool has_data() const;

--- a/src/streaming/file.handle.cpp
+++ b/src/streaming/file.handle.cpp
@@ -115,7 +115,7 @@ zarr::FileHandlePool::evict_lru_()
     for (auto it = lru_order_.rbegin(); it != lru_order_.rend(); ++it) {
         if (auto cache_it = cache_.find(*it);
             cache_it != cache_.end() && cache_it->second.refcount == 0) {
-            cache_.erase(cache_it); // destroys FileHandle -> flush_file
+            cache_.erase(cache_it); // destroys FileHandle -> close
             lru_order_.erase(std::next(it).base());
             return;
         }

--- a/src/streaming/win32/platform.cpp
+++ b/src/streaming/win32/platform.cpp
@@ -86,6 +86,23 @@ init_handle(const std::string& filename, const void* flags)
     return fd;
 }
 
+namespace {
+// One manual-reset event per worker thread, reused across writes. The files
+// are opened FILE_FLAG_OVERLAPPED and we wait synchronously on each write, so
+// a fresh kernel event was being created and destroyed on every single chunk
+// write. Reusing a thread-local event removes that per-write syscall pair.
+struct ThreadEvent
+{
+    HANDLE handle{ CreateEventA(nullptr, TRUE, FALSE, nullptr) };
+    ~ThreadEvent()
+    {
+        if (handle) {
+            CloseHandle(handle);
+        }
+    }
+};
+} // namespace
+
 bool
 seek_and_write(void* handle, size_t offset, ConstByteSpan data)
 {
@@ -95,12 +112,21 @@ seek_and_write(void* handle, size_t offset, ConstByteSpan data)
     auto* cur = reinterpret_cast<const char*>(data.data());
     auto* end = cur + data.size();
 
+    thread_local ThreadEvent thread_event;
+    const HANDLE event = thread_event.handle;
+    if (event == nullptr) {
+        LOG_ERROR("Failed to create overlapped event: ",
+                  get_last_error_as_string());
+        return false;
+    }
+
     int retries = 0;
     OVERLAPPED overlapped = { 0 };
-    overlapped.hEvent = CreateEventA(nullptr, TRUE, FALSE, nullptr);
+    overlapped.hEvent = event;
 
     constexpr auto max_retries = 3;
     while (cur < end && retries < max_retries) {
+        ResetEvent(event); // clear state from the previous write
         DWORD written = 0;
         const auto remaining = static_cast<DWORD>(end - cur); // may truncate
         overlapped.Pointer = reinterpret_cast<void*>(offset);
@@ -108,14 +134,12 @@ seek_and_write(void* handle, size_t offset, ConstByteSpan data)
             GetLastError() != ERROR_IO_PENDING) {
             const auto err = get_last_error_as_string();
             LOG_ERROR("Failed to write to file: ", err);
-            CloseHandle(overlapped.hEvent);
             return false;
         }
 
         if (!GetOverlappedResult(*fd, &overlapped, &written, TRUE)) {
             LOG_ERROR("Failed to get overlapped result: ",
                       get_last_error_as_string());
-            CloseHandle(overlapped.hEvent);
             return false;
         }
         retries += written == 0 ? 1 : 0;
@@ -123,7 +147,6 @@ seek_and_write(void* handle, size_t offset, ConstByteSpan data)
         cur += written;
     }
 
-    CloseHandle(overlapped.hEvent);
     return retries < max_retries;
 }
 
@@ -143,7 +166,11 @@ destroy_handle(void* handle)
 {
     if (const auto* fd = static_cast<HANDLE*>(handle)) {
         if (*fd != INVALID_HANDLE_VALUE) {
-            FlushFileBuffers(*fd); // Ensure all buffers are flushed
+            // No FlushFileBuffers here: sinks are explicitly flushed at
+            // finalize (flush_file -> FlushFileBuffers), so forcing a physical
+            // disk sync on every handle eviction/close is redundant and very
+            // expensive. CloseHandle still flushes written data to the OS
+            // cache, so the store is correct/readable after close.
             CloseHandle(*fd);
         }
         delete fd;

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -7,7 +7,8 @@
 
 #include <blosc.h>
 
-#include <bit> // bit_ceil
+#include <algorithm> // clamp
+#include <bit>        // bit_ceil
 #include <filesystem>
 #include <regex>
 #include <stack>
@@ -1596,10 +1597,14 @@ ZarrStream_s::init_frame_queue_()
         frame_size_bytes = std::max(frame_size_bytes, output->frame_size_bytes);
     }
 
-    // cap the frame buffer at 2 GiB, or 10 frames, whichever is larger
-    constexpr auto buffer_size_bytes = 2ULL << 30;
-    const auto frame_count =
-      std::max(10ULL, buffer_size_bytes / frame_size_bytes);
+    // Bound the frame queue so a fast producer decouples from the consumer
+    // without buffering the whole acquisition in RAM (otherwise peak RSS grows
+    // to ~the dataset size). Target 256 MiB, clamped to [16, 512] frames so
+    // tiny frames don't explode the slot count and huge frames still get
+    // enough buffering to absorb bursts.
+    constexpr uint64_t buffer_size_bytes = 256ULL << 20;
+    const auto frame_count = std::clamp<uint64_t>(
+      buffer_size_bytes / frame_size_bytes, 16ULL, 512ULL);
 
     try {
         frame_queue_ =


### PR DESCRIPTION
## Streaming write-path performance improvements

Four focused commits on the local-filesystem write path. ~1.3–1.9× throughput across regimes and ~3× lower peak RSS. All non-S3 tests pass (34/34).

### Changes
- **build:** enable AVX2 + LTO for the streaming library
- **memory:** bound the frame queue to 256 MiB
- **win32:** reuse the per-handle OVERLAPPED event, drop per-close `FlushFileBuffers`
- **array:** copy frames directly into chunk buffers

### Results
Benchmark: 1024×1024 `uint16`, 512 frames (1 GiB), random data (worst case for compressors). `perf/bench_stream.py` scorecard, pre-patch vs full branch.

| regime | throughput | peak RSS |
|--------|-----------|----------|
| std (s4, ct32) | 682 → 867 MB/s (+27%) | 1019 → 345 MiB (−66%) |
| manyfiles (s1) | 349 → 581 MB/s (+67%) | 1070 → 505 MiB (−53%) |
| rollover (ct1) | 135 → 252 MB/s (+86%) | 1022 → 376 MiB (−63%) |
| threads4       | 552 → 887 MB/s (+61%) | 1015 → 617 MiB (−39%) |
| lz4 (blosc)    | 457 → 661 MB/s (+45%) | 1066 → 426 MiB (−60%) |
| multiscale     | 278 → 401 MB/s (+44%) | 1058 → 335 MiB (−68%) |

### Tradeoff
Bounding the queue trades peak memory for tail latency: `append()` now blocks under backpressure instead of buffering, so per-frame p99 rises (std 7 → 14 ms; worst case `rollover` 7 → 57 ms). Mean/median throughput climbs everywhere; the cost is confined to the tail when the producer outruns the writers.