### PR TITLE
Flush large intermediate dimensions band-by-band to bound memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Flush incrementally along a large intermediate dimension: when the append dimension has a chunk size of 1, chunk
+  buffers are now flushed and freed one band at a time along the dimension just inside the append axis, so peak memory
+  tracks a single band rather than the whole inner volume. This makes large intermediate axes (e.g. a `[t, z, y, x]`
+  store with a ~62k `z`) feasible without running out of memory. `estimate_max_memory_usage` reflects the reduced bound
+  (czbiohub-sf/livescreen-acquisition#210)
 - Bound the frame queue to 256 MiB; `append()` now applies backpressure instead of buffering unboundedly, cutting
   peak memory ~3x at the cost of higher tail latency under sustained pressure (#230)
 - Copy frames directly into chunk buffers, removing an intermediate copy (~1.3-1.9x write throughput on filesystem) (#230)
@@ -22,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `estimate_max_memory_usage` now models the frame queue as the actual 256 MiB / [16, 512]-frame bound (#230) instead
+  of a flat 1 GiB, so the estimate matches real peak usage
 - Shard flush (`fsync`) failures are no longer swallowed in the `Shard` destructor; an I/O error now fails the
   stream instead of silently producing corrupt shards. Python `close()` raises on a failed flush (#231)
 

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -310,12 +310,14 @@ def test_estimate_max_memory_usage():
     )
     for dim in array.dimensions[1:]:
         array_usage *= dim.array_size_px
-    frame_queue_usage = 1 << 30
     frame_buffer_usage = (
         array.dimensions[-2].array_size_px
         * array.dimensions[-1].array_size_px
         * np.dtype(np.uint16).itemsize
     )
+    # mirror init_frame_queue_: 256 MiB budget clamped to [16, 512] frames
+    frame_queue_frames = min(max((256 << 20) // frame_buffer_usage, 16), 512)
+    frame_queue_usage = frame_queue_frames * frame_buffer_usage
     expected_memory = array_usage + frame_buffer_usage + frame_queue_usage
 
     stream = aqz.StreamSettings(arrays=[array])

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -387,23 +387,14 @@ def test_stream_data_to_filesystem(
 
 @pytest.mark.parametrize("ragged", [False, True])
 def test_intermediate_dimension_courtesy_flush(store_path: Path, ragged: bool):
-    """A large intermediate (z) dimension with an append chunk size of 1 must
-    flush and free chunk buffers one z band at a time instead of buffering the
-    entire inner volume.
-
-    Regression guard for the OOM reported in
-    czbiohub-sf/livescreen-acquisition#210 (z up to ~62.5k as an intermediate
-    axis). We verify both that data still round-trips and that live memory never
-    approaches the full inner volume (which the old code allocated up front).
+    """Large intermediate z with append chunk 1: data round-trips and live
+    memory stays well below the full inner volume (czbiohub-sf/livescreen-acquisition#210).
     """
     Y, X, cz = 64, 64, 64
-    # 1024 (16 even bands) or 1000 (ragged trailing band) along z
-    Z = 1000 if ragged else 1024
+    Z = 1000 if ragged else 1024  # ragged trailing band when not a multiple
     dtype = np.uint16
 
-    # two full timepoints, then a partial one whose plane count is neither a
-    # full layer nor a multiple of cz, exercising the close-time flush of the
-    # trailing (partial) band and the entirely-empty bands after it
+    # full timepoints, then a partial one to exercise the close-time flush
     n_full_t = 2
     partial_planes = (Z // 2) + 7
     n_t = n_full_t + 1
@@ -422,9 +413,7 @@ def test_intermediate_dimension_courtesy_flush(store_path: Path, ragged: bool):
                 kind=DimensionType.SPACE,
                 array_size_px=Z,
                 chunk_size_px=cz,
-                # 16 chunks / shard of 3 => a trailing shard with missing chunks,
-                # exercising the padding-skip path at the last band of the layer
-                shard_size_chunks=3,
+                shard_size_chunks=3,  # doesn't divide 16 chunks: tests padding
             ),
             Dimension(
                 name="y",
@@ -454,10 +443,10 @@ def test_intermediate_dimension_courtesy_flush(store_path: Path, ragged: bool):
     band_bytes = cz * Y * X * itemsize
     frame_bytes = Y * X * itemsize
 
-    # frame queue: 256 MiB budget clamped to [16, 512] frames (init_frame_queue_)
+    # frame queue: 256 MiB clamped to [16, 512] frames
     frame_queue_bytes = min(max((256 << 20) // frame_bytes, 16), 512) * frame_bytes
 
-    # the advertised maximum reflects a single z band, not the whole volume
+    # the maximum reflects a single z band, not the whole volume
     expected_max = frame_queue_bytes + band_bytes + frame_bytes
     assert s.get_maximum_memory_usage() == expected_max
 
@@ -482,9 +471,7 @@ def test_intermediate_dimension_courtesy_flush(store_path: Path, ragged: bool):
 
     stream.close()
 
-    # appending one z plane at a time keeps the frame queue tiny, so live memory
-    # is dominated by resident chunk buffers; band-by-band flushing keeps that
-    # well under the full inner volume the old code held resident.
+    # band-by-band flushing keeps live memory well under the full inner volume
     assert peak < int(full_inner_volume * 0.75), (
         f"peak memory {peak} not bounded below the full inner volume "
         f"{full_inner_volume}"

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -385,6 +385,116 @@ def test_stream_data_to_filesystem(
         assert data_file_path.stat().st_size == shard_size_bytes
 
 
+@pytest.mark.parametrize("ragged", [False, True])
+def test_intermediate_dimension_courtesy_flush(store_path: Path, ragged: bool):
+    """A large intermediate (z) dimension with an append chunk size of 1 must
+    flush and free chunk buffers one z band at a time instead of buffering the
+    entire inner volume.
+
+    Regression guard for the OOM reported in
+    czbiohub-sf/livescreen-acquisition#210 (z up to ~62.5k as an intermediate
+    axis). We verify both that data still round-trips and that live memory never
+    approaches the full inner volume (which the old code allocated up front).
+    """
+    Y, X, cz = 64, 64, 64
+    # 1024 (16 even bands) or 1000 (ragged trailing band) along z
+    Z = 1000 if ragged else 1024
+    dtype = np.uint16
+
+    # two full timepoints, then a partial one whose plane count is neither a
+    # full layer nor a multiple of cz, exercising the close-time flush of the
+    # trailing (partial) band and the entirely-empty bands after it
+    n_full_t = 2
+    partial_planes = (Z // 2) + 7
+    n_t = n_full_t + 1
+
+    arr = ArraySettings(
+        dimensions=[
+            Dimension(
+                name="t",
+                kind=DimensionType.TIME,
+                array_size_px=0,
+                chunk_size_px=1,
+                shard_size_chunks=1,
+            ),
+            Dimension(
+                name="z",
+                kind=DimensionType.SPACE,
+                array_size_px=Z,
+                chunk_size_px=cz,
+                # 16 chunks / shard of 3 => a trailing shard with missing chunks,
+                # exercising the padding-skip path at the last band of the layer
+                shard_size_chunks=3,
+            ),
+            Dimension(
+                name="y",
+                kind=DimensionType.SPACE,
+                array_size_px=Y,
+                chunk_size_px=Y,
+                shard_size_chunks=1,
+            ),
+            Dimension(
+                name="x",
+                kind=DimensionType.SPACE,
+                array_size_px=X,
+                chunk_size_px=X,
+                shard_size_chunks=1,
+            ),
+        ]
+    )
+    arr.data_type = dtype
+
+    s = StreamSettings()
+    s.store_path = str(store_path / "intermediate.zarr")
+    s.overwrite = True
+    s.arrays = [arr]
+
+    itemsize = np.dtype(dtype).itemsize
+    full_inner_volume = Z * Y * X * itemsize
+    band_bytes = cz * Y * X * itemsize
+    frame_bytes = Y * X * itemsize
+
+    # frame queue: 256 MiB budget clamped to [16, 512] frames (init_frame_queue_)
+    frame_queue_bytes = min(max((256 << 20) // frame_bytes, 16), 512) * frame_bytes
+
+    # the advertised maximum reflects a single z band, not the whole volume
+    expected_max = frame_queue_bytes + band_bytes + frame_bytes
+    assert s.get_maximum_memory_usage() == expected_max
+
+    stream = ZarrStream(s)
+    assert stream
+
+    expected = np.zeros((n_t, Z, Y, X), dtype=dtype)
+    peak = 0
+
+    def write_t(t: int, n_planes: int):
+        nonlocal peak
+        for z in range(n_planes):
+            value = (t * Z + z) % np.iinfo(dtype).max
+            frame = np.full((Y, X), value, dtype=dtype)
+            expected[t, z] = frame
+            stream.append(frame)
+            peak = max(peak, stream.get_current_memory_usage())
+
+    for t in range(n_full_t):
+        write_t(t, Z)
+    write_t(n_full_t, partial_planes)  # trailing partial layer
+
+    stream.close()
+
+    # appending one z plane at a time keeps the frame queue tiny, so live memory
+    # is dominated by resident chunk buffers; band-by-band flushing keeps that
+    # well under the full inner volume the old code held resident.
+    assert peak < int(full_inner_volume * 0.75), (
+        f"peak memory {peak} not bounded below the full inner volume "
+        f"{full_inner_volume}"
+    )
+
+    array = zarr.open(s.store_path, mode="r")
+    assert array.shape == (n_t, Z, Y, X)
+    assert np.array_equal(array[:], expected)
+
+
 def _make_data(settings: StreamSettings) -> np.ndarray:
     return np.zeros(
         (

--- a/src/streaming/acquire.zarr.cpp
+++ b/src/streaming/acquire.zarr.cpp
@@ -3,8 +3,9 @@
 #include "zarr.common.hh"
 #include "zarr.stream.hh"
 
-#include <bit>     // bit_ceil
-#include <cstdint> // uint32_t
+#include <algorithm> // std::clamp, std::max
+#include <bit>       // bit_ceil
+#include <cstdint>   // uint32_t
 #include <unordered_set>
 #include <vector>
 
@@ -234,7 +235,29 @@ extern "C"
 
         EXPECT_VALID_ARGUMENT(usage, "Null pointer: usage");
 
-        *usage = (1 << 30); // start with 1 GiB for the frame queue
+        // Mirror ZarrStream_s::init_frame_queue_: the shared frame queue is
+        // bounded to ~256 MiB worth of frames, clamped to [16, 512] slots sized
+        // by the largest array's frame.
+        size_t max_frame_size_bytes = 0;
+        for (size_t i = 0; i < settings->array_count; ++i) {
+            const auto& array = settings->arrays[i];
+            const auto& dims = array.dimensions;
+            const auto& ndims = array.dimension_count;
+            const size_t frame_size_bytes =
+              zarr::bytes_of_type(array.data_type) *
+              dims[ndims - 2].array_size_px * dims[ndims - 1].array_size_px;
+            max_frame_size_bytes =
+              std::max(max_frame_size_bytes, frame_size_bytes);
+        }
+
+        constexpr uint64_t frame_queue_budget_bytes = 256ULL << 20;
+        if (max_frame_size_bytes > 0) {
+            const auto frame_count = std::clamp<uint64_t>(
+              frame_queue_budget_bytes / max_frame_size_bytes, 16ULL, 512ULL);
+            *usage = frame_count * max_frame_size_bytes;
+        } else {
+            *usage = 0;
+        }
 
         for (size_t i = 0; i < settings->array_count; ++i) {
             const auto& array = settings->arrays[i];
@@ -248,6 +271,19 @@ extern "C"
 
             *usage += frame_size_bytes; // each array has a frame buffer
 
+            // With an append chunk of 1 and at least one intermediate
+            // dimension, the writer flushes and frees one dim-1 chunk band at a
+            // time (see Array::flush_completed_bands_), so peak memory tracks a
+            // single band along the first intermediate axis rather than the
+            // full inner volume.
+            // @see issue czbiohub-sf/livescreen-acquisition#210
+            // Banding is disabled under a requested transposition (see
+            // ArrayDimensions::supports_dim1_banding), so only claim the reduced
+            // bound when storage order matches acquisition order; otherwise this
+            // estimate must stay a true upper bound.
+            const bool banded = dims[0].chunk_size_px == 1 && ndims >= 4 &&
+                                array.storage_dimension_order == nullptr;
+
             size_t array_usage = bytes_of_type * dims[0].chunk_size_px;
             for (auto j = 1; j < ndims; ++j) {
                 const auto& dim = dims[j];
@@ -257,7 +293,11 @@ extern "C"
                   dim.array_size_px, dim.chunk_size_px);
                 size_t padded_array_size_px = nchunks * dim.chunk_size_px;
 
-                array_usage *= padded_array_size_px;
+                if (banded && j == 1) {
+                    array_usage *= dim.chunk_size_px;
+                } else {
+                    array_usage *= padded_array_size_px;
+                }
             }
 
             // compression can instantaneously double memory usage in the worst

--- a/src/streaming/acquire.zarr.cpp
+++ b/src/streaming/acquire.zarr.cpp
@@ -235,9 +235,8 @@ extern "C"
 
         EXPECT_VALID_ARGUMENT(usage, "Null pointer: usage");
 
-        // Mirror ZarrStream_s::init_frame_queue_: the shared frame queue is
-        // bounded to ~256 MiB worth of frames, clamped to [16, 512] slots sized
-        // by the largest array's frame.
+        // frame queue: mirror init_frame_queue_ (256 MiB, clamped to [16, 512]
+        // frames sized by the largest array's frame)
         size_t max_frame_size_bytes = 0;
         for (size_t i = 0; i < settings->array_count; ++i) {
             const auto& array = settings->arrays[i];
@@ -271,16 +270,9 @@ extern "C"
 
             *usage += frame_size_bytes; // each array has a frame buffer
 
-            // With an append chunk of 1 and at least one intermediate
-            // dimension, the writer flushes and frees one dim-1 chunk band at a
-            // time (see Array::flush_completed_bands_), so peak memory tracks a
-            // single band along the first intermediate axis rather than the
-            // full inner volume.
-            // @see issue czbiohub-sf/livescreen-acquisition#210
-            // Banding is disabled under a requested transposition (see
-            // ArrayDimensions::supports_dim1_banding), so only claim the reduced
-            // bound when storage order matches acquisition order; otherwise this
-            // estimate must stay a true upper bound.
+            // banding bounds memory to one dim-1 band; mirror
+            // supports_dim1_banding (no transposition) to stay an upper bound
+            // @see czbiohub-sf/livescreen-acquisition#210
             const bool banded = dims[0].chunk_size_px == 1 && ndims >= 4 &&
                                 array.storage_dimension_order == nullptr;
 

--- a/src/streaming/array.cpp
+++ b/src/streaming/array.cpp
@@ -103,15 +103,10 @@ zarr::Array::Array(std::shared_ptr<ArrayConfig> config,
     const size_t n_chunks = config_->dimensions->number_of_chunks_in_memory();
     EXPECT(n_chunks > 0, "Array has zero chunks in memory");
 
-    // Chunk buffers are allocated lazily on first write (write_frame_to_chunks_)
-    // and freed as each band/layer is flushed, so peak memory tracks the live
-    // working set rather than the full inner volume.
+    // allocated lazily on write, freed per band/layer on flush
     chunks_.resize(n_chunks);
 
-    // Incremental band flushing requires an append chunk of 1 (see
-    // ArrayDimensions::supports_dim1_banding); with a larger append chunk every
-    // inner chunk must stay resident until the append chunk completes. Warn when
-    // that working set is large so the resulting memory pressure is diagnosable.
+    // append chunk > 1 keeps the whole inner volume resident (no banding); warn
     const auto& dims = *config_->dimensions;
     if (dims.final_dim().chunk_size_px > 1 && dims.ndims() >= 4) {
         const size_t layer_bytes =
@@ -212,8 +207,6 @@ zarr::Array::write_frame(std::vector<uint8_t>& frame,
               frames_written);
 
     if (config_->dimensions->supports_dim1_banding()) {
-        // flush completed dim-1 bands incrementally so peak memory stays bounded
-        // to one band rather than the whole inner volume
         CHECK(flush_completed_bands_());
     } else if (should_flush_()) {
         CHECK(compress_and_flush_data_());
@@ -386,8 +379,7 @@ zarr::Array::close_()
     try {
         if (bytes_to_flush_ > 0) {
             if (config_->dimensions->supports_dim1_banding()) {
-                // bands flushed mid-sweep are already on disk and freed; flush
-                // only the trailing (possibly partial) bands of the open layer
+                // flush the trailing bands of the open layer
                 CHECK(flush_layer_remainder_());
             } else {
                 CHECK(compress_and_flush_data_());
@@ -680,9 +672,7 @@ zarr::Array::dispatch_chunk_job_(std::shared_ptr<Shard> shard,
 {
     std::shared_ptr<Chunk> chunk;
     {
-        // take the chunk out of its slot, leaving it empty; the next layer
-        // reallocates lazily on write, so the buffer is reclaimed once this job
-        // finishes with it
+        // take the chunk out of its slot; the next layer reallocates lazily
         std::unique_lock lock(chunk_mutexes_[chunk_idx - chunk_offset]);
         chunk = std::move(chunks_[chunk_idx - chunk_offset]);
     }
@@ -788,8 +778,8 @@ zarr::Array::compress_and_flush_data_()
     const size_t bytes_per_chunk = dims->bytes_per_chunk();
     const size_t bytes_per_px = bytes_of_type(config_->dtype);
 
-    // compress and write every chunk in the current layer, skipping ragged
-    // padding slots so each shard's countdown completes
+    // write every chunk in the layer; skip ragged padding to complete each
+    // shard's countdown
     for (auto shard_idx = 0; shard_idx < n_shards; ++shard_idx) {
         auto shard = shards_[shard_idx];
 
@@ -838,8 +828,7 @@ zarr::Array::compress_and_flush_band_(uint32_t band_idx, uint32_t n_bands)
     const size_t bytes_per_chunk = dims->bytes_per_chunk();
     const size_t bytes_per_px = bytes_of_type(config_->dtype);
 
-    // chunks of one band occupy a contiguous block of the in-memory layout,
-    // since dimension 1 is the slowest-varying chunk index within a layer
+    // a band is a contiguous block of slots (dim 1 is the slowest chunk index)
     const auto chunks_per_band = chunks_in_mem / n_bands;
     const auto local_begin = band_idx * chunks_per_band;
     const auto local_end = local_begin + chunks_per_band;
@@ -856,10 +845,7 @@ zarr::Array::compress_and_flush_band_(uint32_t band_idx, uint32_t n_bands)
                             bytes_per_px);
     }
 
-    // the final band of the layer accounts for ragged padding across all shards
-    // (slots backed by no lattice chunk, possibly in shards the band never
-    // touched) so every shard's unwritten-chunk countdown reaches zero exactly
-    // once
+    // on the last band, account for ragged padding across all shards
     if (band_idx + 1 == n_bands) {
         for (auto shard_idx = 0; shard_idx < n_shards; ++shard_idx) {
             for (const auto& internal_idx :
@@ -893,12 +879,10 @@ zarr::Array::flush_completed_bands_()
     const auto frames_per_band = dims->frames_per_dim1_band();
     const auto n_bands = dims->dim1_band_count();
 
-    // frames written into the current append-chunk layer
     const auto frames_in_layer = frames_written_() % frames_per_layer;
 
     if (frames_in_layer == 0) {
-        // the layer just completed: flush any bands not yet flushed (the
-        // trailing, possibly ragged, band) and account for padding
+        // layer complete: flush the trailing band(s) and advance/rollover
         CHECK(flush_layer_remainder_());
 
         if (should_rollover_()) {
@@ -911,7 +895,7 @@ zarr::Array::flush_completed_bands_()
         bytes_to_flush_ = 0;
         flushed_band_count_ = 0;
     } else if (frames_in_layer % frames_per_band == 0) {
-        // one or more interior bands just completed; flush any not yet flushed
+        // flush interior bands completed since the last flush
         const auto completed =
           static_cast<uint32_t>(frames_in_layer / frames_per_band);
         for (auto band = flushed_band_count_; band < completed; ++band) {

--- a/src/streaming/array.cpp
+++ b/src/streaming/array.cpp
@@ -98,16 +98,38 @@ zarr::Array::Array(std::shared_ptr<ArrayConfig> config,
   , is_closing_{ false }
   , last_successful_frame_id_{ 0 }
   , current_layer_{ 0 }
+  , flushed_band_count_{ 0 }
 {
     const size_t n_chunks = config_->dimensions->number_of_chunks_in_memory();
     EXPECT(n_chunks > 0, "Array has zero chunks in memory");
 
-    const size_t bytes_per_chunk = config_->dimensions->bytes_per_chunk();
-    const size_t bytes_per_px = bytes_of_type(config_->dtype);
-
+    // Chunk buffers are allocated lazily on first write (write_frame_to_chunks_)
+    // and freed as each band/layer is flushed, so peak memory tracks the live
+    // working set rather than the full inner volume.
     chunks_.resize(n_chunks);
-    for (auto& chunk : chunks_) {
-        chunk = std::make_shared<Chunk>(bytes_per_chunk, bytes_per_px);
+
+    // Incremental band flushing requires an append chunk of 1 (see
+    // ArrayDimensions::supports_dim1_banding); with a larger append chunk every
+    // inner chunk must stay resident until the append chunk completes. Warn when
+    // that working set is large so the resulting memory pressure is diagnosable.
+    const auto& dims = *config_->dimensions;
+    if (dims.final_dim().chunk_size_px > 1 && dims.ndims() >= 4) {
+        const size_t layer_bytes =
+          static_cast<size_t>(dims.number_of_chunks_in_memory()) *
+          dims.bytes_per_chunk();
+        constexpr size_t warn_threshold = size_t{ 1 } << 30; // 1 GiB
+        if (layer_bytes > warn_threshold) {
+            LOG_WARNING("Append dimension '",
+                        dims.final_dim().name,
+                        "' has chunk size ",
+                        dims.final_dim().chunk_size_px,
+                        " (> 1), so ~",
+                        layer_bytes >> 20,
+                        " MiB of chunk buffers must stay resident until each "
+                        "append chunk completes; set its chunk size to 1 to "
+                        "enable incremental flushing of large intermediate "
+                        "dimensions.");
+        }
     }
 
     // For 2D arrays, don't include append_chunk_index in the path
@@ -125,7 +147,9 @@ zarr::Array::memory_usage() const noexcept
     // safe to read without locking.
     size_t total = 0;
     for (const auto& chunk : chunks_) {
-        total += chunk->size_bytes();
+        if (chunk) { // slots are empty until lazily allocated on write
+            total += chunk->size_bytes();
+        }
     }
 
     return total;
@@ -187,7 +211,11 @@ zarr::Array::write_frame(std::vector<uint8_t>& frame,
               "; frames written: ",
               frames_written);
 
-    if (should_flush_()) {
+    if (config_->dimensions->supports_dim1_banding()) {
+        // flush completed dim-1 bands incrementally so peak memory stays bounded
+        // to one band rather than the whole inner volume
+        CHECK(flush_completed_bands_());
+    } else if (should_flush_()) {
         CHECK(compress_and_flush_data_());
 
         if (should_rollover_()) {
@@ -357,7 +385,13 @@ zarr::Array::close_()
     is_closing_ = true;
     try {
         if (bytes_to_flush_ > 0) {
-            CHECK(compress_and_flush_data_());
+            if (config_->dimensions->supports_dim1_banding()) {
+                // bands flushed mid-sweep are already on disk and freed; flush
+                // only the trailing (possibly partial) bands of the open layer
+                CHECK(flush_layer_remainder_());
+            } else {
+                CHECK(compress_and_flush_data_());
+            }
         }
 
         {
@@ -595,6 +629,146 @@ zarr::Array::write_frame_to_chunks_(std::vector<uint8_t>& frame)
     return bytes_written;
 }
 
+void
+zarr::Array::dispatch_skip_job_(std::shared_ptr<Shard> shard,
+                                uint32_t internal_idx,
+                                uint32_t shard_idx)
+{
+    write_counter_.fetch_add(1);
+    write_counter_cv_.notify_all();
+
+    auto job = [this, shard, internal_idx, shard_idx](
+                 std::string& err) -> ThreadPool::TaskResult {
+        ThreadPool::TaskResult result;
+
+        try {
+            if (shard->skip_chunk(internal_idx)) {
+                result = ThreadPool::TaskResult::Success;
+            } else { // failed to write table / flush shard
+                err = "Failed to skip chunk " + std::to_string(internal_idx) +
+                      " of shard " + std::to_string(shard_idx);
+                result = ThreadPool::TaskResult::Fatal;
+            }
+        } catch (const std::exception& exc) {
+            err = std::string("Failed skipping chunk: ") + exc.what();
+            result = ThreadPool::TaskResult::Fatal;
+        }
+
+        write_counter_.fetch_sub(1);
+        write_counter_cv_.notify_all();
+        return result;
+    };
+
+    // one thread is reserved for processing the frame queue and runs the
+    // entire lifetime of the stream
+    if (thread_pool_->n_threads() == 1 || !thread_pool_->push_job(job)) {
+        if (!thread_pool_->execute_job(std::move(job))) {
+            LOG_ERROR(
+              "Failed to skip chunk ", internal_idx, " of shard ", shard_idx);
+        }
+    }
+}
+
+void
+zarr::Array::dispatch_chunk_job_(std::shared_ptr<Shard> shard,
+                                 uint32_t chunk_idx,
+                                 uint32_t internal_idx,
+                                 uint32_t shard_idx,
+                                 uint32_t chunk_offset,
+                                 size_t bytes_per_chunk,
+                                 size_t bytes_per_px)
+{
+    std::shared_ptr<Chunk> chunk;
+    {
+        // take the chunk out of its slot, leaving it empty; the next layer
+        // reallocates lazily on write, so the buffer is reclaimed once this job
+        // finishes with it
+        std::unique_lock lock(chunk_mutexes_[chunk_idx - chunk_offset]);
+        chunk = std::move(chunks_[chunk_idx - chunk_offset]);
+    }
+
+    write_counter_.fetch_add(1);
+    write_counter_cv_.notify_all();
+
+    auto job = [this,
+                shard,
+                internal_idx,
+                chunk_idx,
+                shard_idx,
+                chunk = std::move(chunk),
+                params = config_->compression_params](
+                 std::string& err) -> ThreadPool::TaskResult {
+        ThreadPool::TaskResult result;
+
+        constexpr size_t n_retries = 3;
+
+        try {
+            auto try_write = [&](const auto& write_fn) {
+                for (auto retry = 0; retry < n_retries; ++retry) {
+                    if (write_fn()) {
+                        return true;
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(
+                      static_cast<int>(std::pow(10, retry))));
+                }
+                return false;
+            };
+
+            auto retries_exhausted_msg = [&] {
+                return "Failed to write chunk " + std::to_string(chunk_idx) +
+                       " of shard " + std::to_string(shard_idx) + " after " +
+                       std::to_string(n_retries) + " attempts";
+            };
+
+            if (!chunk || !chunk->has_data()) {
+                if (try_write(
+                      [&] { return shard->skip_chunk(internal_idx); })) {
+                    result = ThreadPool::TaskResult::Success;
+                } else {
+                    err = retries_exhausted_msg();
+                    result = ThreadPool::TaskResult::Fatal;
+                }
+            } else {
+                std::vector<uint8_t> compressed;
+                if (!chunk->compress_and_take_buffer(params, compressed)) {
+                    err = "Failed to compress chunk " +
+                          std::to_string(chunk_idx) + " of shard " +
+                          std::to_string(shard_idx);
+                    result = ThreadPool::TaskResult::Fatal;
+                } else if (try_write([&] {
+                               return shard->write_chunk(internal_idx,
+                                                         compressed);
+                           })) {
+                    result = ThreadPool::TaskResult::Success;
+                } else {
+                    err = retries_exhausted_msg();
+                    result = ThreadPool::TaskResult::Fatal;
+                }
+            }
+        } catch (const std::exception& exc) {
+            err = std::string("Failed to write chunk: ") + exc.what();
+            result = ThreadPool::TaskResult::Fatal;
+        }
+
+        write_counter_.fetch_sub(1);
+        write_counter_cv_.notify_all();
+        return result;
+    };
+
+    // one thread is reserved for processing the frame queue and runs the
+    // entire lifetime of the stream
+    if (thread_pool_->n_threads() == 1 || !thread_pool_->push_job(job)) {
+        if (!thread_pool_->execute_job_with_retry(std::move(job), 2)) {
+            LOG_ERROR("Failed to write chunk ",
+                      chunk_idx,
+                      ", (internal index ",
+                      internal_idx,
+                      ") of shard ",
+                      shard_idx);
+        }
+    }
+}
+
 bool
 zarr::Array::compress_and_flush_data_()
 {
@@ -611,166 +785,29 @@ zarr::Array::compress_and_flush_data_()
     const auto chunks_in_mem = dims->number_of_chunks_in_memory();
     const auto chunk_offset = current_layer_ * chunks_in_mem;
 
-    const size_t bytes_per_chunk = config_->dimensions->bytes_per_chunk();
+    const size_t bytes_per_chunk = dims->bytes_per_chunk();
     const size_t bytes_per_px = bytes_of_type(config_->dtype);
 
-    // wait for the chunks in each shard to finish compressing, then defragment
-    // and write the shard
+    // compress and write every chunk in the current layer, skipping ragged
+    // padding slots so each shard's countdown completes
     for (auto shard_idx = 0; shard_idx < n_shards; ++shard_idx) {
         auto shard = shards_[shard_idx];
-        const auto chunk_indices_this_layer =
-          dims->chunk_indices_for_shard_layer(shard_idx, current_layer_);
 
-        // skip empty chunks
-        const auto empty_chunks =
-          dims->skipped_internal_indices_for_shard_layer(shard_idx,
-                                                         current_layer_);
-
-        for (const auto& internal_idx : empty_chunks) {
-            write_counter_.fetch_add(1);
-            write_counter_cv_.notify_all();
-
-            auto job = [this, shard, internal_idx, shard_idx](
-                         std::string& err) -> ThreadPool::TaskResult {
-                bool success = false;
-                ThreadPool::TaskResult result;
-
-                try {
-                    success = shard->skip_chunk(internal_idx);
-                    if (success) {
-                        result = ThreadPool::TaskResult::Success;
-                    } else { // failed to write table / flush shard
-                        err = "Failed to skip chunk " +
-                              std::to_string(internal_idx) + " of shard " +
-                              std::to_string(shard_idx);
-                        result = ThreadPool::TaskResult::Fatal;
-                    }
-                } catch (const std::exception& exc) {
-                    err = std::string("Failed skipping chunk: ") + exc.what();
-                    result = ThreadPool::TaskResult::Fatal;
-                }
-
-                write_counter_.fetch_sub(1);
-                write_counter_cv_.notify_all();
-                return result;
-            };
-
-            // one thread is reserved for processing the frame queue and
-            // runs the entire lifetime of the stream
-            if (thread_pool_->n_threads() == 1 ||
-                !thread_pool_->push_job(job)) {
-                if (!thread_pool_->execute_job(std::move(job))) {
-                    LOG_ERROR("Failed to skip chunk ",
-                              internal_idx,
-                              " of shard ",
-                              shard_idx);
-                }
-            }
+        for (const auto& internal_idx :
+             dims->skipped_internal_indices_for_shard_layer(shard_idx,
+                                                            current_layer_)) {
+            dispatch_skip_job_(shard, internal_idx, shard_idx);
         }
 
-        for (const auto& chunk_idx : chunk_indices_this_layer) {
-            auto& chunk = chunks_[chunk_idx - chunk_offset];
-            const auto internal_idx = dims->shard_internal_index(chunk_idx);
-            write_counter_.fetch_add(1);
-            write_counter_cv_.notify_all();
-
-            auto job = [this,
-                        shard,
-                        internal_idx,
-                        chunk_idx,
-                        chunk_offset,
-                        shard_idx,
-                        bytes_per_chunk,
-                        bytes_per_px,
-                        chunk = std::move(chunk),
-                        params = config_->compression_params](
-                         std::string& err) -> ThreadPool::TaskResult {
-                ThreadPool::TaskResult result;
-
-                constexpr size_t n_retries = 3;
-
-                try {
-                    // reset chunk slot for the next layer
-                    {
-                        std::unique_lock lock(
-                          chunk_mutexes_[chunk_idx - chunk_offset]);
-
-                        if (!chunks_[chunk_idx - chunk_offset]) {
-                            chunks_[chunk_idx - chunk_offset] =
-                              std::make_shared<Chunk>(bytes_per_chunk,
-                                                      bytes_per_px);
-                        }
-                    }
-
-                    auto try_write = [&](const auto& write_fn) {
-                        for (auto retry = 0; retry < n_retries; ++retry) {
-                            if (write_fn()) {
-                                return true;
-                            }
-                            std::this_thread::sleep_for(
-                              std::chrono::milliseconds(
-                                static_cast<int>(std::pow(10, retry))));
-                        }
-                        return false;
-                    };
-
-                    auto retries_exhausted_msg = [&] {
-                        return "Failed to write chunk " +
-                               std::to_string(chunk_idx) + " of shard " +
-                               std::to_string(shard_idx) + " after " +
-                               std::to_string(n_retries) + " attempts";
-                    };
-
-                    if (!chunk->has_data()) {
-                        if (try_write([&] {
-                                return shard->skip_chunk(internal_idx);
-                            })) {
-                            result = ThreadPool::TaskResult::Success;
-                        } else {
-                            err = retries_exhausted_msg();
-                            result = ThreadPool::TaskResult::Fatal;
-                        }
-                    } else {
-                        std::vector<uint8_t> compressed;
-                        if (!chunk->compress_and_take_buffer(params,
-                                                             compressed)) {
-                            err = "Failed to compress chunk " +
-                                  std::to_string(chunk_idx) + " of shard " +
-                                  std::to_string(shard_idx);
-                            result = ThreadPool::TaskResult::Fatal;
-                        } else if (try_write([&] {
-                                       return shard->write_chunk(internal_idx,
-                                                                 compressed);
-                                   })) {
-                            result = ThreadPool::TaskResult::Success;
-                        } else {
-                            err = retries_exhausted_msg();
-                            result = ThreadPool::TaskResult::Fatal;
-                        }
-                    }
-                } catch (const std::exception& exc) {
-                    err = std::string("Failed to write chunk: ") + exc.what();
-                    result = ThreadPool::TaskResult::Fatal;
-                }
-
-                write_counter_.fetch_sub(1);
-                write_counter_cv_.notify_all();
-                return result;
-            };
-
-            // one thread is reserved for processing the frame queue and
-            // runs the entire lifetime of the stream
-            if (thread_pool_->n_threads() == 1 ||
-                !thread_pool_->push_job(job)) {
-                if (!thread_pool_->execute_job_with_retry(std::move(job), 2)) {
-                    LOG_ERROR("Failed to write chunk ",
-                              chunk_idx,
-                              ", (internal index ",
-                              internal_idx,
-                              ") of shard ",
-                              shard_idx);
-                }
-            }
+        for (const auto& chunk_idx :
+             dims->chunk_indices_for_shard_layer(shard_idx, current_layer_)) {
+            dispatch_chunk_job_(shard,
+                                chunk_idx,
+                                dims->shard_internal_index(chunk_idx),
+                                shard_idx,
+                                chunk_offset,
+                                bytes_per_chunk,
+                                bytes_per_px);
         }
     }
 
@@ -778,6 +815,109 @@ zarr::Array::compress_and_flush_data_()
         current_layer_ = 0;
     } else {
         ++current_layer_;
+    }
+
+    return true;
+}
+
+bool
+zarr::Array::compress_and_flush_band_(uint32_t band_idx, uint32_t n_bands)
+{
+    if (data_paths_.empty()) {
+        make_shards_();
+    }
+
+    const auto& dims = config_->dimensions;
+
+    const auto n_shards = dims->number_of_shards();
+    CHECK(shards_.size() == n_shards);
+
+    const auto chunks_in_mem = dims->number_of_chunks_in_memory();
+    const auto chunk_offset = current_layer_ * chunks_in_mem;
+
+    const size_t bytes_per_chunk = dims->bytes_per_chunk();
+    const size_t bytes_per_px = bytes_of_type(config_->dtype);
+
+    // chunks of one band occupy a contiguous block of the in-memory layout,
+    // since dimension 1 is the slowest-varying chunk index within a layer
+    const auto chunks_per_band = chunks_in_mem / n_bands;
+    const auto local_begin = band_idx * chunks_per_band;
+    const auto local_end = local_begin + chunks_per_band;
+
+    for (auto local_idx = local_begin; local_idx < local_end; ++local_idx) {
+        const auto chunk_idx = chunk_offset + local_idx;
+        const auto shard_idx = dims->shard_index_for_chunk(chunk_idx);
+        dispatch_chunk_job_(shards_[shard_idx],
+                            chunk_idx,
+                            dims->shard_internal_index(chunk_idx),
+                            shard_idx,
+                            chunk_offset,
+                            bytes_per_chunk,
+                            bytes_per_px);
+    }
+
+    // the final band of the layer accounts for ragged padding across all shards
+    // (slots backed by no lattice chunk, possibly in shards the band never
+    // touched) so every shard's unwritten-chunk countdown reaches zero exactly
+    // once
+    if (band_idx + 1 == n_bands) {
+        for (auto shard_idx = 0; shard_idx < n_shards; ++shard_idx) {
+            for (const auto& internal_idx :
+                 dims->skipped_internal_indices_for_shard_layer(
+                   shard_idx, current_layer_)) {
+                dispatch_skip_job_(shards_[shard_idx], internal_idx, shard_idx);
+            }
+        }
+    }
+
+    return true;
+}
+
+bool
+zarr::Array::flush_layer_remainder_()
+{
+    const auto n_bands = config_->dimensions->dim1_band_count();
+    for (auto band = flushed_band_count_; band < n_bands; ++band) {
+        CHECK(compress_and_flush_band_(band, n_bands));
+    }
+    flushed_band_count_ = n_bands;
+    return true;
+}
+
+bool
+zarr::Array::flush_completed_bands_()
+{
+    const auto& dims = config_->dimensions;
+
+    const auto frames_per_layer = dims->frames_per_chunk_layer();
+    const auto frames_per_band = dims->frames_per_dim1_band();
+    const auto n_bands = dims->dim1_band_count();
+
+    // frames written into the current append-chunk layer
+    const auto frames_in_layer = frames_written_() % frames_per_layer;
+
+    if (frames_in_layer == 0) {
+        // the layer just completed: flush any bands not yet flushed (the
+        // trailing, possibly ragged, band) and account for padding
+        CHECK(flush_layer_remainder_());
+
+        if (should_rollover_()) {
+            rollover_();
+            CHECK(write_metadata_());
+            current_layer_ = 0;
+        } else {
+            ++current_layer_;
+        }
+        bytes_to_flush_ = 0;
+        flushed_band_count_ = 0;
+    } else if (frames_in_layer % frames_per_band == 0) {
+        // one or more interior bands just completed; flush any not yet flushed
+        const auto completed =
+          static_cast<uint32_t>(frames_in_layer / frames_per_band);
+        for (auto band = flushed_band_count_; band < completed; ++band) {
+            CHECK(compress_and_flush_band_(band, n_bands));
+        }
+        flushed_band_count_ = completed;
     }
 
     return true;

--- a/src/streaming/array.dimensions.cpp
+++ b/src/streaming/array.dimensions.cpp
@@ -344,13 +344,8 @@ ArrayDimensions::frames_per_shard_layer() const
 bool
 ArrayDimensions::supports_dim1_banding() const
 {
-    // Need an append chunk of 1 (so each inner sweep completes its chunks) and
-    // at least one intermediate dimension (index 1 must not be spatial).
-    //
-    // Banding triggers off the acquisition frame count, so it requires that
-    // acquisition order matches storage order; under transposition a storage
-    // band's frames arrive out of sequence and a band could be flushed before
-    // it is complete, so fall back to whole-layer flushing.
+    // append chunk 1 (each sweep completes its chunks) + an intermediate dim;
+    // transposition would desync the acquisition-order frame trigger
     return dims_.front().chunk_size_px == 1 && ndims() >= 4 &&
            !needs_transposition();
 }

--- a/src/streaming/array.dimensions.cpp
+++ b/src/streaming/array.dimensions.cpp
@@ -325,6 +325,58 @@ ArrayDimensions::bytes_per_chunk() const
     return bytes_per_chunk_;
 }
 
+uint64_t
+ArrayDimensions::frames_per_chunk_layer() const
+{
+    uint64_t frames = dims_.front().chunk_size_px;
+    for (auto i = 1; i + 2 < ndims(); ++i) { // intermediate dims: 1..ndims-3
+        frames *= dims_[i].array_size_px;
+    }
+    return frames;
+}
+
+uint64_t
+ArrayDimensions::frames_per_shard_layer() const
+{
+    return frames_per_chunk_layer() * dims_.front().shard_size_chunks;
+}
+
+bool
+ArrayDimensions::supports_dim1_banding() const
+{
+    // Need an append chunk of 1 (so each inner sweep completes its chunks) and
+    // at least one intermediate dimension (index 1 must not be spatial).
+    //
+    // Banding triggers off the acquisition frame count, so it requires that
+    // acquisition order matches storage order; under transposition a storage
+    // band's frames arrive out of sequence and a band could be flushed before
+    // it is complete, so fall back to whole-layer flushing.
+    return dims_.front().chunk_size_px == 1 && ndims() >= 4 &&
+           !needs_transposition();
+}
+
+uint32_t
+ArrayDimensions::dim1_band_count() const
+{
+    return zarr::chunks_along_dimension(dims_[1]);
+}
+
+uint64_t
+ArrayDimensions::frames_per_dim1_band() const
+{
+    uint64_t frames = dims_[1].chunk_size_px;
+    for (auto i = 2; i + 2 < ndims(); ++i) { // dims inside dim 1: 2..ndims-3
+        frames *= dims_[i].array_size_px;
+    }
+    return frames;
+}
+
+uint32_t
+ArrayDimensions::chunks_per_dim1_band() const
+{
+    return number_of_chunks_in_memory_ / dim1_band_count();
+}
+
 uint32_t
 ArrayDimensions::number_of_shards() const
 {

--- a/src/streaming/array.dimensions.hh
+++ b/src/streaming/array.dimensions.hh
@@ -131,51 +131,24 @@ class ArrayDimensions
      */
     uint32_t number_of_chunks_in_memory() const;
 
-    /**
-     * @brief Number of frames that fill one chunk along the append dimension.
-     * @details This is the granularity at which a full inner volume is flushed
-     * today (see Array::should_flush_): append chunk size times the product of
-     * the intermediate (non-append, non-spatial) array sizes.
-     */
+    /// Frames that fill one append-dimension chunk (the whole-layer flush size).
     uint64_t frames_per_chunk_layer() const;
 
-    /**
-     * @brief Number of frames that fill one shard along the append dimension.
-     * @details append chunk size times append shard size (in chunks) times the
-     * product of the intermediate array sizes; the rollover granularity.
-     */
+    /// Frames that fill one append-dimension shard (the rollover size).
     uint64_t frames_per_shard_layer() const;
 
-    /**
-     * @brief Whether incremental ("courtesy") flushing along dimension 1 can
-     * bound peak memory below a full inner volume.
-     * @details Only possible when the append-dimension chunk size is 1 and at
-     * least one intermediate dimension exists. With append chunk size > 1, a
-     * chunk spans multiple inner sweeps, so every inner chunk must stay resident
-     * until the append chunk completes and incremental flushing cannot help.
-     * @see issue czbiohub-sf/livescreen-acquisition#210
-     */
+    /// Whether dim-1 band flushing applies: append chunk size 1, an
+    /// intermediate dim, and no transposition.
+    /// @see czbiohub-sf/livescreen-acquisition#210
     bool supports_dim1_banding() const;
 
-    /**
-     * @brief Number of dim-1 chunk bands per append-chunk layer.
-     * @return chunks_along_dimension(dim 1) -- the count of incremental flushes
-     * per layer when banding is active.
-     */
+    /// Number of dim-1 chunk bands per layer (== chunks along dim 1).
     uint32_t dim1_band_count() const;
 
-    /**
-     * @brief Number of frames that fill one dim-1 chunk band.
-     * @return dim-1 chunk size times the product of array sizes of the
-     * intermediate dimensions inside dim 1. For [t, z, y, x] this is the z chunk
-     * size.
-     */
+    /// Frames that fill one dim-1 chunk band (z chunk size for [t, z, y, x]).
     uint64_t frames_per_dim1_band() const;
 
-    /**
-     * @brief Number of in-memory chunks belonging to a single dim-1 band.
-     * @return number_of_chunks_in_memory() / dim1_band_count().
-     */
+    /// In-memory chunks per dim-1 band (number_of_chunks_in_memory / bands).
     uint32_t chunks_per_dim1_band() const;
 
     /**

--- a/src/streaming/array.dimensions.hh
+++ b/src/streaming/array.dimensions.hh
@@ -132,6 +132,53 @@ class ArrayDimensions
     uint32_t number_of_chunks_in_memory() const;
 
     /**
+     * @brief Number of frames that fill one chunk along the append dimension.
+     * @details This is the granularity at which a full inner volume is flushed
+     * today (see Array::should_flush_): append chunk size times the product of
+     * the intermediate (non-append, non-spatial) array sizes.
+     */
+    uint64_t frames_per_chunk_layer() const;
+
+    /**
+     * @brief Number of frames that fill one shard along the append dimension.
+     * @details append chunk size times append shard size (in chunks) times the
+     * product of the intermediate array sizes; the rollover granularity.
+     */
+    uint64_t frames_per_shard_layer() const;
+
+    /**
+     * @brief Whether incremental ("courtesy") flushing along dimension 1 can
+     * bound peak memory below a full inner volume.
+     * @details Only possible when the append-dimension chunk size is 1 and at
+     * least one intermediate dimension exists. With append chunk size > 1, a
+     * chunk spans multiple inner sweeps, so every inner chunk must stay resident
+     * until the append chunk completes and incremental flushing cannot help.
+     * @see issue czbiohub-sf/livescreen-acquisition#210
+     */
+    bool supports_dim1_banding() const;
+
+    /**
+     * @brief Number of dim-1 chunk bands per append-chunk layer.
+     * @return chunks_along_dimension(dim 1) -- the count of incremental flushes
+     * per layer when banding is active.
+     */
+    uint32_t dim1_band_count() const;
+
+    /**
+     * @brief Number of frames that fill one dim-1 chunk band.
+     * @return dim-1 chunk size times the product of array sizes of the
+     * intermediate dimensions inside dim 1. For [t, z, y, x] this is the z chunk
+     * size.
+     */
+    uint64_t frames_per_dim1_band() const;
+
+    /**
+     * @brief Number of in-memory chunks belonging to a single dim-1 band.
+     * @return number_of_chunks_in_memory() / dim1_band_count().
+     */
+    uint32_t chunks_per_dim1_band() const;
+
+    /**
      * @brief Get the size, in bytes, of a single raw chunk.
      * @return The number of bytes to allocate for a chunk.
      */

--- a/src/streaming/array.hh
+++ b/src/streaming/array.hh
@@ -50,6 +50,10 @@ class Array : public ArrayBase
     uint64_t last_successful_frame_id_;
     uint32_t current_layer_;
 
+    // number of dim-1 chunk bands already flushed in the current append-chunk
+    // layer (only meaningful when dimensions->supports_dim1_banding())
+    uint32_t flushed_band_count_;
+
     bool make_metadata_(nlohmann::json& metadata) override;
     [[nodiscard]] bool close_() override;
 
@@ -65,6 +69,33 @@ class Array : public ArrayBase
     size_t write_frame_to_chunks_(std::vector<uint8_t>& frame);
 
     [[nodiscard]] bool compress_and_flush_data_();
+
+    // Incremental ("courtesy") flushing along dimension 1, used when
+    // dimensions->supports_dim1_banding(). Flushes and frees one band of chunks
+    // at a time as the inner sweep completes them, bounding peak raw memory to a
+    // single band instead of the full inner volume.
+    // @see issue czbiohub-sf/livescreen-acquisition#210
+    [[nodiscard]] bool flush_completed_bands_();
+    [[nodiscard]] bool flush_layer_remainder_();
+    [[nodiscard]] bool compress_and_flush_band_(uint32_t band_idx,
+                                                uint32_t n_bands);
+
+    // Dispatch a single chunk's compress-and-write (or skip-if-empty) job,
+    // moving the chunk out of its slot and leaving the slot empty so the buffer
+    // is reclaimed; the next layer reallocates it lazily on write.
+    void dispatch_chunk_job_(std::shared_ptr<Shard> shard,
+                             uint32_t chunk_idx,
+                             uint32_t internal_idx,
+                             uint32_t shard_idx,
+                             uint32_t chunk_offset,
+                             size_t bytes_per_chunk,
+                             size_t bytes_per_px);
+    // Dispatch a skip for a shard-internal index backed by no lattice chunk
+    // (ragged padding), so the shard's unwritten-chunk countdown completes.
+    void dispatch_skip_job_(std::shared_ptr<Shard> shard,
+                            uint32_t internal_idx,
+                            uint32_t shard_idx);
+
     void rollover_();
     void close_sinks_();
 

--- a/src/streaming/array.hh
+++ b/src/streaming/array.hh
@@ -50,8 +50,7 @@ class Array : public ArrayBase
     uint64_t last_successful_frame_id_;
     uint32_t current_layer_;
 
-    // number of dim-1 chunk bands already flushed in the current append-chunk
-    // layer (only meaningful when dimensions->supports_dim1_banding())
+    // dim-1 bands flushed so far in the current layer (banding only)
     uint32_t flushed_band_count_;
 
     bool make_metadata_(nlohmann::json& metadata) override;
@@ -70,19 +69,15 @@ class Array : public ArrayBase
 
     [[nodiscard]] bool compress_and_flush_data_();
 
-    // Incremental ("courtesy") flushing along dimension 1, used when
-    // dimensions->supports_dim1_banding(). Flushes and frees one band of chunks
-    // at a time as the inner sweep completes them, bounding peak raw memory to a
-    // single band instead of the full inner volume.
-    // @see issue czbiohub-sf/livescreen-acquisition#210
+    // Incremental flush along dimension 1, one chunk band at a time, to bound
+    // peak memory. Used when dimensions->supports_dim1_banding().
+    // @see czbiohub-sf/livescreen-acquisition#210
     [[nodiscard]] bool flush_completed_bands_();
     [[nodiscard]] bool flush_layer_remainder_();
     [[nodiscard]] bool compress_and_flush_band_(uint32_t band_idx,
                                                 uint32_t n_bands);
 
-    // Dispatch a single chunk's compress-and-write (or skip-if-empty) job,
-    // moving the chunk out of its slot and leaving the slot empty so the buffer
-    // is reclaimed; the next layer reallocates it lazily on write.
+    // Compress and write (or skip-if-empty) one chunk, freeing its slot.
     void dispatch_chunk_job_(std::shared_ptr<Shard> shard,
                              uint32_t chunk_idx,
                              uint32_t internal_idx,
@@ -90,8 +85,7 @@ class Array : public ArrayBase
                              uint32_t chunk_offset,
                              size_t bytes_per_chunk,
                              size_t bytes_per_px);
-    // Dispatch a skip for a shard-internal index backed by no lattice chunk
-    // (ragged padding), so the shard's unwritten-chunk countdown completes.
+    // Skip a ragged-padding slot to complete the shard's countdown.
     void dispatch_skip_job_(std::shared_ptr<Shard> shard,
                             uint32_t internal_idx,
                             uint32_t shard_idx);

--- a/tests/integration/estimate-memory-usage.cpp
+++ b/tests/integration/estimate-memory-usage.cpp
@@ -1,6 +1,7 @@
 #include "acquire.zarr.h"
 #include "test.macros.hh"
 
+#include <algorithm>
 #include <cstring>
 #include <filesystem>
 #include <thread>
@@ -78,8 +79,12 @@ test_max_memory_usage()
     const std::string output_key1 = "test_array1";
     initialize_array(settings.arrays[0], output_key1, false, false);
 
-    const size_t frame_queue_size = 1 << 30; // 1 GiB
     const size_t expected_frame_size = array_width * array_height * 2;
+
+    // mirror init_frame_queue_: 256 MiB budget clamped to [16, 512] frames
+    const size_t frame_queue_frames =
+      std::clamp<size_t>((256ULL << 20) / expected_frame_size, 16, 512);
+    const size_t frame_queue_size = frame_queue_frames * expected_frame_size;
 
     const size_t padded_width = padded_size(array_width, chunk_width);
     const size_t padded_height = padded_size(array_height, chunk_height);

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(tests
         array-dimensions-chunk-internal-offset
         array-dimensions-shard-index-for-chunk
         array-dimensions-shard-internal-index
+        array-dimensions-courtesy-flush
         thread-pool-push-to-job-queue
         construct-data-paths
         s3-connection-bucket-exists

--- a/tests/unit-tests/array-dimensions-courtesy-flush.cpp
+++ b/tests/unit-tests/array-dimensions-courtesy-flush.cpp
@@ -1,0 +1,123 @@
+// Unit coverage for the dim-1 "courtesy flush" band math that lets a large
+// intermediate dimension stream incrementally instead of buffering the whole
+// inner volume.
+// @see issue czbiohub-sf/livescreen-acquisition#210
+#include "array.dimensions.hh"
+#include "unit.test.macros.hh"
+
+#include <stdexcept>
+
+namespace {
+ArrayDimensions
+make_dims(std::vector<ZarrDimension> dims,
+          const std::vector<size_t>& order = {})
+{
+    return ArrayDimensions(std::move(dims), ZarrDataType_uint16, order);
+}
+} // namespace
+
+int
+main()
+{
+    int retval = 1;
+
+    try {
+        // [t, z, y, x] with append chunk size 1 and a chunked intermediate z:
+        // this is the reported layout. Banding is active and z is the band axis.
+        {
+            std::vector<ZarrDimension> dims;
+            dims.emplace_back("t", ZarrDimensionType_Time, 0, 1, 1);
+            dims.emplace_back("z", ZarrDimensionType_Space, 1000, 64, 3);
+            dims.emplace_back("y", ZarrDimensionType_Space, 64, 64, 1);
+            dims.emplace_back("x", ZarrDimensionType_Space, 64, 64, 1);
+            auto d = make_dims(std::move(dims));
+
+            EXPECT(d.supports_dim1_banding(), "Expected banding to be enabled");
+            // ceil(1000 / 64) == 16 bands along z
+            EXPECT_EQ(int, d.dim1_band_count(), 16);
+            // one z chunk's worth of frames per band (no dims inside z)
+            EXPECT_EQ(int, d.frames_per_dim1_band(), 64);
+            // a whole z volume per append-chunk layer
+            EXPECT_EQ(int, d.frames_per_chunk_layer(), 1000);
+            EXPECT_EQ(int, d.frames_per_shard_layer(), 1000); // t shard == 1
+            // y, x are single chunks, so each band is exactly one chunk
+            EXPECT_EQ(int, d.chunks_per_dim1_band(), 1);
+            EXPECT_EQ(int,
+                      d.chunks_per_dim1_band() * d.dim1_band_count(),
+                      d.number_of_chunks_in_memory());
+        }
+
+        // Append chunk size > 1 disables banding (inner chunks span sweeps).
+        {
+            std::vector<ZarrDimension> dims;
+            dims.emplace_back("t", ZarrDimensionType_Time, 0, 4, 1);
+            dims.emplace_back("z", ZarrDimensionType_Space, 256, 64, 1);
+            dims.emplace_back("y", ZarrDimensionType_Space, 64, 64, 1);
+            dims.emplace_back("x", ZarrDimensionType_Space, 64, 64, 1);
+            auto d = make_dims(std::move(dims));
+
+            EXPECT(!d.supports_dim1_banding(),
+                   "Expected banding disabled for append chunk > 1");
+            // append chunk (4) * z array (256)
+            EXPECT_EQ(int, d.frames_per_chunk_layer(), 1024);
+        }
+
+        // No intermediate dimension ([t, y, x]) disables banding.
+        {
+            std::vector<ZarrDimension> dims;
+            dims.emplace_back("t", ZarrDimensionType_Time, 0, 1, 1);
+            dims.emplace_back("y", ZarrDimensionType_Space, 64, 64, 1);
+            dims.emplace_back("x", ZarrDimensionType_Space, 64, 64, 1);
+            auto d = make_dims(std::move(dims));
+
+            EXPECT(!d.supports_dim1_banding(),
+                   "Expected banding disabled without an intermediate dim");
+        }
+
+        // A requested transposition disables banding: acquisition order would
+        // not match storage order, so band-completion timing is unreliable.
+        {
+            std::vector<ZarrDimension> dims;
+            dims.emplace_back("t", ZarrDimensionType_Time, 0, 1, 1);
+            dims.emplace_back("c", ZarrDimensionType_Channel, 4, 2, 1);
+            dims.emplace_back("z", ZarrDimensionType_Space, 256, 64, 1);
+            dims.emplace_back("y", ZarrDimensionType_Space, 64, 64, 1);
+            dims.emplace_back("x", ZarrDimensionType_Space, 64, 64, 1);
+            // store order [t, z, c, y, x] -- a non-identity permutation
+            auto d = make_dims(std::move(dims), { 0, 2, 1, 3, 4 });
+
+            EXPECT(!d.supports_dim1_banding(),
+                   "Expected banding disabled under transposition");
+        }
+
+        // Multiple intermediate dims [t, a, b, y, x]: bands run along a (dim 1)
+        // and each band spans a full sweep of b.
+        {
+            std::vector<ZarrDimension> dims;
+            dims.emplace_back("t", ZarrDimensionType_Time, 0, 1, 1);
+            dims.emplace_back("a", ZarrDimensionType_Space, 8, 2, 1);
+            dims.emplace_back("b", ZarrDimensionType_Space, 10, 5, 1);
+            dims.emplace_back("y", ZarrDimensionType_Space, 64, 64, 1);
+            dims.emplace_back("x", ZarrDimensionType_Space, 64, 64, 1);
+            auto d = make_dims(std::move(dims));
+
+            EXPECT(d.supports_dim1_banding(), "Expected banding to be enabled");
+            EXPECT_EQ(int, d.dim1_band_count(), 4); // ceil(8 / 2) bands along a
+            // a chunk (2) * full b array (10)
+            EXPECT_EQ(int, d.frames_per_dim1_band(), 20);
+            // a array (8) * b array (10)
+            EXPECT_EQ(int, d.frames_per_chunk_layer(), 80);
+            // chunks_per_band == chunks across b, y, x = 2 * 1 * 1
+            EXPECT_EQ(int, d.chunks_per_dim1_band(), 2);
+            EXPECT_EQ(int,
+                      d.chunks_per_dim1_band() * d.dim1_band_count(),
+                      d.number_of_chunks_in_memory());
+        }
+
+        retval = 0;
+    } catch (const std::exception& exc) {
+        LOG_ERROR("Exception: ", exc.what());
+    }
+
+    return retval;
+}

--- a/tests/unit-tests/array-dimensions-courtesy-flush.cpp
+++ b/tests/unit-tests/array-dimensions-courtesy-flush.cpp
@@ -1,7 +1,5 @@
-// Unit coverage for the dim-1 "courtesy flush" band math that lets a large
-// intermediate dimension stream incrementally instead of buffering the whole
-// inner volume.
-// @see issue czbiohub-sf/livescreen-acquisition#210
+// Band math for dim-1 "courtesy flush".
+// @see czbiohub-sf/livescreen-acquisition#210
 #include "array.dimensions.hh"
 #include "unit.test.macros.hh"
 
@@ -22,8 +20,7 @@ main()
     int retval = 1;
 
     try {
-        // [t, z, y, x] with append chunk size 1 and a chunked intermediate z:
-        // this is the reported layout. Banding is active and z is the band axis.
+        // [t, z, y, x], append chunk 1, chunked z: the reported layout
         {
             std::vector<ZarrDimension> dims;
             dims.emplace_back("t", ZarrDimensionType_Time, 0, 1, 1);
@@ -74,8 +71,7 @@ main()
                    "Expected banding disabled without an intermediate dim");
         }
 
-        // A requested transposition disables banding: acquisition order would
-        // not match storage order, so band-completion timing is unreliable.
+        // a requested transposition disables banding
         {
             std::vector<ZarrDimension> dims;
             dims.emplace_back("t", ZarrDimensionType_Time, 0, 1, 1);
@@ -90,8 +86,7 @@ main()
                    "Expected banding disabled under transposition");
         }
 
-        // Multiple intermediate dims [t, a, b, y, x]: bands run along a (dim 1)
-        // and each band spans a full sweep of b.
+        // multiple intermediate dims [t, a, b, y, x]: bands run along a (dim 1)
         {
             std::vector<ZarrDimension> dims;
             dims.emplace_back("t", ZarrDimensionType_Time, 0, 1, 1);


### PR DESCRIPTION
## Problem

When the append dimension has a chunk size of 1 and there is at least one intermediate dimension (e.g. `[t, z, y, x]` where `z` is a large grid/position axis), the writer buffered the **entire inner volume** before its first flush — a flush only fired once a whole append-chunk layer had arrived. With a ~62k intermediate axis this exhausts memory.

Reported downstream in czbiohub-sf/livescreen-acquisition#210 (per-camera scanning store reshaped to `[t, grid, y, x]`, `grid` up to ~62.5k).

## Change

Flush and free chunk buffers **one band at a time** along the dimension just inside the append axis as the inner sweep completes them, so peak raw memory tracks a single band instead of the full inner volume.

- Chunk buffers are now allocated lazily and reclaimed per band (previously the full inner volume was allocated up front in the `Array` ctor).
- Shards already stream compressed chunks to disk and self-finalize via the `unwritten_chunks_` countdown, so shards spanning multiple bands (or finishing mid-sweep) finalize correctly with no extra buffering.
- The per-chunk write/skip job dispatch was extracted into helpers shared by the whole-layer and banded paths.

### Scope / fallbacks

- Banding requires **append chunk size == 1** and **no transposition** (otherwise inner chunks span multiple sweeps, or acquisition order ≠ storage order, so a band could be flushed before it is complete). In those cases the previous whole-layer flush is kept, plus a one-line warning when the resident working set is large.
- Only bands along the dimension immediately inside the append axis; a huge intermediate dim that is *not* dim-1 is out of scope (the reported case has it as dim-1).

### Memory estimate

`estimate_max_memory_usage` now reports the reduced (single-band) bound when banding applies, and is also corrected to model the frame queue as the actual 256 MiB / [16, 512]-frame bound (#230) rather than a flat 1 GiB.

## Tests

- `array-dimensions-courtesy-flush` (unit): band-math helpers across even/ragged/multi-intermediate/transposed/no-intermediate configs.
- `test_intermediate_dimension_courtesy_flush` (Python, parametrized even/ragged z, with a trailing partial timepoint): full data round-trip, band-based memory estimate, and a guard that live memory stays well below the full inner volume.
- Updated `estimate-memory-usage` (C++) and `test_estimate_max_memory_usage` (Python) for the corrected queue bound.

Existing coverage guards the unchanged paths: `array-write-ragged-internal-dim` (append chunk > 1), `stream-multi-frame-append`, and `stream-with-ragged-final-shard` (banding with a single band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)