### PR TITLE
Truncate metadata writes; allow concurrent reads on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Filesystem files are now opened with `FILE_SHARE_READ` on Windows, so another process (e.g. napari) can open the
-  store for reading while an acquisition is in progress (PR_NUMBER)
+  store for reading while an acquisition is in progress (#234)
 
 ### Fixed
 
 - Metadata (`zarr.json`) writes now truncate the file to the written length. Previously a rewrite shorter than the
   prior version (e.g. replacing a large custom-metadata blob with a smaller one) left stale trailing bytes, since
   neither the Win32 nor POSIX backend truncated on write; strict JSON parsers such as zarr-python rejected the
-  result (PR_NUMBER)
+  result (#234)
 
 ## [0.8.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Filesystem files are now opened with `FILE_SHARE_READ` on Windows, so another process (e.g. napari) can open the
+  store for reading while an acquisition is in progress (PR_NUMBER)
+
+### Fixed
+
+- Metadata (`zarr.json`) writes now truncate the file to the written length. Previously a rewrite shorter than the
+  prior version (e.g. replacing a large custom-metadata blob with a smaller one) left stale trailing bytes, since
+  neither the Win32 nor POSIX backend truncated on write; strict JSON parsers such as zarr-python rejected the
+  result (PR_NUMBER)
+
 ## [0.8.1]
 
 ### Added

--- a/src/streaming/array.base.cpp
+++ b/src/streaming/array.base.cpp
@@ -76,7 +76,7 @@ zarr::ArrayBase::make_metadata_sink_()
         auto sink =
           config_->bucket_name
             ? make_s3_sink(*config_->bucket_name, path, s3_connection_pool_)
-            : make_file_sink(path, file_handle_pool_);
+            : make_file_sink(path, file_handle_pool_, /*truncate_to_fit=*/true);
         if (!sink) {
             LOG_ERROR("Failed to create metadata sink for path: ", path);
             return false;

--- a/src/streaming/file.sink.cpp
+++ b/src/streaming/file.sink.cpp
@@ -9,10 +9,15 @@ seek_and_write(void* handle, size_t offset, ConstByteSpan data);
 bool
 flush_file(void* handle);
 
+bool
+truncate_file(void* handle, size_t size);
+
 zarr::FileSink::FileSink(std::string_view filename,
-                         std::shared_ptr<FileHandlePool> file_handle_pool)
+                         std::shared_ptr<FileHandlePool> file_handle_pool,
+                         bool truncate_to_fit)
   : file_handle_pool_(file_handle_pool)
   , filename_(filename)
+  , truncate_to_fit_(truncate_to_fit)
 {
     EXPECT(file_handle_pool_ != nullptr, "File handle pool not provided.");
 }
@@ -33,6 +38,10 @@ zarr::FileSink::write(size_t offset, ConstByteSpan data)
     bool retval = false;
     try {
         retval = seek_and_write(borrowed.handle_->get(), offset, data);
+        if (retval && truncate_to_fit_) {
+            retval =
+              truncate_file(borrowed.handle_->get(), offset + data.size());
+        }
     } catch (const std::exception& exc) {
         LOG_ERROR("Failed to write to file ", filename_, ": ", exc.what());
     }

--- a/src/streaming/file.sink.cpp
+++ b/src/streaming/file.sink.cpp
@@ -29,6 +29,17 @@ zarr::FileSink::write(size_t offset, ConstByteSpan data)
         return true;
     }
 
+    // truncate_to_fit_ clamps the file to offset + data.size(), which is only
+    // correct for a whole-file write at 0; a later write at a lower offset would
+    // truncate away earlier content. Enforce the invariant at its use site.
+    if (truncate_to_fit_ && offset != 0) {
+        LOG_ERROR("Truncating sink for ",
+                  filename_,
+                  " requires writes at offset 0; got offset ",
+                  offset);
+        return false;
+    }
+
     const auto borrowed = file_handle_pool_->get_handle(filename_);
     if (borrowed.handle_ == nullptr) {
         LOG_ERROR("Failed to get file handle for ", filename_);

--- a/src/streaming/file.sink.hh
+++ b/src/streaming/file.sink.hh
@@ -12,7 +12,8 @@ class FileSink : public Sink
 {
   public:
     FileSink(std::string_view filename,
-             std::shared_ptr<FileHandlePool> file_handle_pool);
+             std::shared_ptr<FileHandlePool> file_handle_pool,
+             bool truncate_to_fit = false);
     ~FileSink() override = default;
 
     bool write(size_t offset, ConstByteSpan data) override;
@@ -24,5 +25,9 @@ class FileSink : public Sink
     std::shared_ptr<FileHandlePool> file_handle_pool_;
 
     std::string filename_;
+
+    // Whole-file replacement: drop bytes past what was written so a shorter
+    // rewrite leaves no stale tail. Used for metadata (single write at 0).
+    bool truncate_to_fit_;
 };
 } // namespace zarr

--- a/src/streaming/posix/platform.cpp
+++ b/src/streaming/posix/platform.cpp
@@ -96,6 +96,22 @@ flush_file(void* handle)
     return res == 0;
 }
 
+bool
+truncate_file(void* handle, size_t size)
+{
+    CHECK(handle);
+    const auto* fd = static_cast<int*>(handle);
+    if (*fd < 0) {
+        return false;
+    }
+
+    if (ftruncate(*fd, static_cast<off_t>(size)) < 0) {
+        LOG_ERROR("Failed to truncate file: ", get_last_error_as_string());
+        return false;
+    }
+    return true;
+}
+
 void
 destroy_handle(void* handle)
 {

--- a/src/streaming/sink.cpp
+++ b/src/streaming/sink.cpp
@@ -101,7 +101,8 @@ zarr::construct_data_paths(std::string_view base_path,
 
 std::unique_ptr<zarr::Sink>
 zarr::make_file_sink(std::string_view file_path,
-                     std::shared_ptr<FileHandlePool> file_handle_pool)
+                     std::shared_ptr<FileHandlePool> file_handle_pool,
+                     bool truncate_to_fit)
 {
     if (file_path.starts_with("file://")) {
         file_path = file_path.substr(7);
@@ -124,7 +125,8 @@ zarr::make_file_sink(std::string_view file_path,
         }
     }
 
-    return std::make_unique<FileSink>(file_path, file_handle_pool);
+    return std::make_unique<FileSink>(
+      file_path, file_handle_pool, truncate_to_fit);
 }
 
 std::unique_ptr<zarr::Sink>

--- a/src/streaming/sink.hh
+++ b/src/streaming/sink.hh
@@ -70,7 +70,8 @@ construct_data_paths(std::string_view base_path,
  */
 std::unique_ptr<Sink>
 make_file_sink(std::string_view file_path,
-               std::shared_ptr<FileHandlePool> file_handle_pool);
+               std::shared_ptr<FileHandlePool> file_handle_pool,
+               bool truncate_to_fit = false);
 
 /**
  * @brief Create a sink from an S3 bucket name and object key.

--- a/src/streaming/win32/platform.cpp
+++ b/src/streaming/win32/platform.cpp
@@ -71,7 +71,7 @@ init_handle(const std::string& filename, const void* flags)
     auto* fd = new HANDLE;
     *fd = CreateFileA(filename.c_str(),
                       GENERIC_WRITE,
-                      FILE_SHARE_WRITE,
+                      FILE_SHARE_READ | FILE_SHARE_WRITE,
                       nullptr,
                       OPEN_ALWAYS,
                       *static_cast<const DWORD*>(flags),
@@ -157,6 +157,27 @@ flush_file(void* handle)
     if (const auto* fd = static_cast<HANDLE*>(handle);
         *fd != INVALID_HANDLE_VALUE) {
         return FlushFileBuffers(*fd);
+    }
+    return true;
+}
+
+bool
+truncate_file(void* handle, size_t size)
+{
+    CHECK(handle);
+    const auto* fd = static_cast<HANDLE*>(handle);
+    if (*fd == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    // FileEndOfFileInfo takes an explicit size and ignores the file pointer,
+    // which FILE_FLAG_OVERLAPPED writes never move (unlike SetEndOfFile).
+    FILE_END_OF_FILE_INFO eof_info = { 0 };
+    eof_info.EndOfFile.QuadPart = static_cast<LONGLONG>(size);
+    if (!SetFileInformationByHandle(
+          *fd, FileEndOfFileInfo, &eof_info, sizeof(eof_info))) {
+        LOG_ERROR("Failed to truncate file: ", get_last_error_as_string());
+        return false;
     }
     return true;
 }

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -1568,7 +1568,8 @@ ZarrStream_s::write_intermediate_metadata_()
             metadata_sink = zarr::make_s3_sink(
               bucket_name.value(), sink_path, s3_connection_pool_);
         } else {
-            metadata_sink = zarr::make_file_sink(sink_path, file_handle_pool_);
+            metadata_sink = zarr::make_file_sink(
+              sink_path, file_handle_pool_, /*truncate_to_fit=*/true);
         }
 
         if (!metadata_sink->write(0, metadata_span) ||

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(project acquire-zarr)
 set(tests
         create-stream
         stream-write-metadata
+        metadata-shrink-stale-bytes
         create-stream-simple-array-root
         array-dimensions-chunk-lattice-index
         array-dimensions-tile-group-offset

--- a/tests/unit-tests/metadata-shrink-stale-bytes.cpp
+++ b/tests/unit-tests/metadata-shrink-stale-bytes.cpp
@@ -1,0 +1,200 @@
+// Reproduces the "shrinking metadata leaves stale trailing bytes" eventuality.
+//
+// Metadata is written at offset 0 through the file sink, and neither backend
+// truncates (Win32 OPEN_ALWAYS; POSIX O_WRONLY|O_CREAT, no O_TRUNC/ftruncate).
+// So if a zarr.json is rewritten *shorter* than a previous version, the tail of
+// the old document survives past the end of the new one. Custom metadata is the
+// way to make the document shrink: write a large blob under `attributes`, then
+// rewrite with a small (or empty) one.
+//
+// This drives that through the public API via two acquisitions to the same
+// store (overwrite=false keeps the first store's zarr.json), then reads the
+// result back two ways:
+//   - ifstream >> json : the codebase's own reader (lenient: stops at the first
+//                        complete value, so it ignores a stale tail)
+//   - json::parse(str) : strict, like zarr-python / napari (json.loads), which
+//                        rejects trailing tokens
+//
+// The test asserts the strict-parse property holds. If the bug is present it
+// fails here, which is the signal we're after.
+
+#include "acquire.zarr.h"
+#include "unit.test.macros.hh"
+
+#include <nlohmann/json.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+const fs::path base_dir = TEST ".zarr";
+const fs::path root_metadata = base_dir / "zarr.json";
+
+void
+configure_stream_dimensions(ZarrArraySettings* settings)
+{
+    CHECK(ZarrStatusCode_Success ==
+          ZarrArraySettings_create_dimension_array(settings, 3));
+
+    settings->dimensions[0] = ZarrDimensionProperties{
+        .name = "t",
+        .type = ZarrDimensionType_Time,
+        .array_size_px = 100,
+        .chunk_size_px = 10,
+        .shard_size_chunks = 1,
+    };
+    settings->dimensions[1] = ZarrDimensionProperties{
+        .name = "y",
+        .type = ZarrDimensionType_Space,
+        .array_size_px = 200,
+        .chunk_size_px = 20,
+        .shard_size_chunks = 1,
+    };
+    settings->dimensions[2] = ZarrDimensionProperties{
+        .name = "x",
+        .type = ZarrDimensionType_Space,
+        .array_size_px = 300,
+        .chunk_size_px = 30,
+        .shard_size_chunks = 1,
+    };
+}
+
+// Create a stream over base_dir. overwrite=false so a second acquisition does
+// not wipe the first one's zarr.json.
+ZarrStream*
+create_stream()
+{
+    const std::string store_path = base_dir.string();
+
+    ZarrStreamSettings settings;
+    memset(&settings, 0, sizeof(settings));
+    settings.store_path = store_path.c_str();
+    settings.overwrite = false;
+
+    CHECK(ZarrStatusCode_Success ==
+          ZarrStreamSettings_create_arrays(&settings, 1));
+    configure_stream_dimensions(settings.arrays);
+
+    auto* stream = ZarrStream_create(&settings);
+    ZarrStreamSettings_destroy_arrays(&settings);
+
+    return stream;
+}
+
+// Write custom metadata to the root zarr.json under `attributes` and close.
+void
+write_root_metadata_and_close(const std::string& metadata_key,
+                              const std::string& metadata_json)
+{
+    auto* stream = create_stream();
+    CHECK(stream);
+
+    CHECK(ZarrStatusCode_Success ==
+          ZarrStream_write_custom_metadata(
+            stream, nullptr, metadata_key.c_str(), metadata_json.c_str()));
+
+    ZarrStream_destroy(stream);
+}
+
+bool
+destroy_directory()
+{
+    std::error_code ec;
+    if (fs::is_directory(base_dir) && !fs::remove_all(base_dir, ec)) {
+        LOG_ERROR("Failed to remove store path: ", ec.message().c_str());
+        return false;
+    }
+    return true;
+}
+
+void
+test_shrinking_metadata_leaves_stale_bytes()
+{
+    CHECK(destroy_directory());
+
+    // 1) First acquisition: a large custom-metadata blob -> large zarr.json.
+    const std::string big_blob(8192, 'x');
+    nlohmann::json big = { { "payload", big_blob } };
+    write_root_metadata_and_close("big", big.dump());
+
+    CHECK(fs::is_regular_file(root_metadata));
+    const auto size_after_big = fs::file_size(root_metadata);
+    LOG_INFO("zarr.json size after large metadata: ", size_after_big);
+
+    // 2) Second acquisition to the same store (overwrite=false): a tiny blob.
+    //    This rewrites zarr.json shorter, at offset 0, with no truncation.
+    write_root_metadata_and_close("small", R"("ok")");
+
+    const auto size_after_small = fs::file_size(root_metadata);
+    LOG_INFO("zarr.json size after small metadata: ", size_after_small);
+
+    // Read the raw file once so we can try both parse strategies on it.
+    std::string contents;
+    {
+        std::ifstream f(root_metadata, std::ios::binary);
+        CHECK(f.is_open());
+        std::ostringstream ss;
+        ss << f.rdbuf();
+        contents = ss.str();
+    }
+
+    // (a) The codebase's own reader: lenient, stops at the first complete value.
+    bool lenient_ok = true;
+    try {
+        std::istringstream is(contents);
+        nlohmann::json j;
+        is >> j;
+    } catch (const std::exception& exc) {
+        lenient_ok = false;
+        LOG_INFO("lenient (operator>>) parse threw: ", exc.what());
+    }
+    LOG_INFO("lenient (operator>>) parse ok: ", lenient_ok);
+
+    // (b) Strict parse, like zarr-python / napari (json.loads): rejects a tail.
+    bool strict_ok = true;
+    std::string strict_err;
+    try {
+        auto j = nlohmann::json::parse(contents);
+    } catch (const std::exception& exc) {
+        strict_ok = false;
+        strict_err = exc.what();
+        LOG_INFO("strict (json::parse) parse threw: ", exc.what());
+    }
+
+    // The property we want: a freshly written zarr.json is always strictly
+    // valid. If the file still carries the old document's tail, this fails --
+    // which is the eventuality we're probing for.
+    EXPECT(strict_ok,
+           "Strict parse of zarr.json failed; stale trailing bytes from the "
+           "previous (larger) metadata likely survived: ",
+           strict_err);
+
+    CHECK(destroy_directory());
+}
+} // namespace
+
+int
+main()
+{
+    int retval = 1;
+    if (!destroy_directory()) {
+        return retval;
+    }
+
+    try {
+        test_shrinking_metadata_leaves_stale_bytes();
+        retval = 0;
+    } catch (const std::exception& exception) {
+        LOG_ERROR(exception.what());
+    }
+
+    if (!destroy_directory()) {
+        retval = 1;
+    }
+
+    return retval;
+}


### PR DESCRIPTION
## Motivation

Two related filesystem issues, surfaced by a request to drag-and-drop an in-progress acquisition into napari on Windows.

1. **Files were locked against readers on Windows.** Handles were opened with `dwShareMode = FILE_SHARE_WRITE` only, so any process opening the store for reading (napari) failed with a sharing violation for the duration of the acquisition.
2. **Shrinking metadata left stale trailing bytes.** `zarr.json` is written as a single whole-file write at offset 0, but neither the Win32 (`OPEN_ALWAYS`) nor POSIX (`O_WRONLY|O_CREAT`) backend truncates. A rewrite shorter than the previous version — e.g. replacing a large custom-metadata blob with a smaller one across two acquisitions to the same store — leaves the tail of the old document past the end of the new one. The library's own reader (nlohmann `operator>>`) stops at the first complete value and tolerated it, but strict parsers like zarr-python (`json.loads`) reject the result.

## Changes

- **Windows share mode:** open filesystem handles with `FILE_SHARE_READ | FILE_SHARE_WRITE` so readers can open the store during acquisition. No write-path / throughput impact — share mode only governs concurrent opens.
- **Truncate-to-fit:** new `truncate_file` platform primitive (`SetFileInformationByHandle(FileEndOfFileInfo)` on Win32, which is file-pointer-independent and so correct for the `FILE_FLAG_OVERLAPPED` handle; `ftruncate` on POSIX) and a `truncate_to_fit` flag on `FileSink` that clamps the file to `offset + data.size()` after a successful write. It is a post-write truncate (not an open-mode flag) because handles are pooled and reused across rewrites. Enabled for the array/root metadata sink and the intermediate group/plate/well metadata sink; data sinks keep the default (no truncation) since they write incrementally at offsets.

## Tests

Adds `tests/unit-tests/metadata-shrink-stale-bytes.cpp`, which reproduces the shrinking-metadata case via two `overwrite=false` acquisitions to the same store and asserts the resulting `zarr.json` is strictly parseable. It fails without the truncate fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)