### PR TITLE
CI: cache vcpkg binaries and add sccache

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,10 @@ jobs:
     permissions:
       actions: write
 
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      CMAKE_ARGS: "-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,10 +49,24 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13.3"
+          cache: 'pip'
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vcpkg/archives
+            ~/AppData/Local/vcpkg/archives
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform }}-
 
       - name: Install vcpkg
         run: |
-          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19
+          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1
           cd vcpkg && ./bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
           echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,9 @@ jobs:
     permissions:
       actions: write
 
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.platform }}-${{ matrix.build_type }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -49,6 +52,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vcpkg/archives
+            ~/AppData/Local/vcpkg/archives
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform }}-
 
       - name: Install CMake 3.31
         if: matrix.platform != 'ubuntu-24.04-arm'
@@ -66,7 +82,7 @@ jobs:
 
       - name: Install vcpkg
         run: |
-          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19
+          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1
           cd vcpkg && ./bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
           echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH
@@ -81,7 +97,7 @@ jobs:
       - name: CMake
         run: |
           cmake --preset=default -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}}
-          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build
         run: |
@@ -137,6 +153,10 @@ jobs:
     permissions:
       actions: write
 
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      CMAKE_ARGS: "-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.platform }}-${{ matrix.python }}-build-wheel
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -150,11 +170,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
+
+      - name: Set up sccache
+        if: ${{ !startsWith(matrix.platform, 'ubuntu') }}
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache vcpkg binaries
+        if: ${{ !startsWith(matrix.platform, 'ubuntu') }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vcpkg/archives
+            ~/AppData/Local/vcpkg/archives
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform }}-
 
       - name: Install vcpkg
         if: ${{ !startsWith(matrix.platform, 'ubuntu') }} # vcpkg will be installed in the manylinux image for Ubuntu builds
         run: |
-          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19
+          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1
           cd vcpkg && ./bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
           echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH
@@ -191,7 +227,7 @@ jobs:
           CIBW_BEFORE_BUILD: >-
             yum install -y ninja-build gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ perl-IPC-Cmd &&
             source /opt/rh/gcc-toolset-11/enable &&
-            git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 &&
+            git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1 &&
             cd vcpkg &&
             CMAKE_POLICY_VERSION_MINIMUM=3.5 ./bootstrap-vcpkg.sh &&
             ./vcpkg integrate install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
     permissions:
       actions: write
 
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.platform }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -45,6 +48,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vcpkg/archives
+            ~/AppData/Local/vcpkg/archives
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform }}-
 
       - name: Install CMake 3.31
         if: matrix.platform != 'ubuntu-24.04-arm'
@@ -62,7 +78,7 @@ jobs:
 
       - name: Install vcpkg
         run: |
-          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19
+          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1
           cd vcpkg && ./bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
           echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH
@@ -89,7 +105,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake --preset=default -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}} -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+          cmake --preset=default -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}} -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           cmake --build ${{github.workspace}}/build --config Release
 
       - name: Test  # don't release if tests are failing
@@ -98,7 +114,7 @@ jobs:
 
       - name: Package
         run: |
-          cmake --preset=default -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}} -B ${{github.workspace}}/pack -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
+          cmake --preset=default -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}} -B ${{github.workspace}}/pack -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           cmake --build ${{github.workspace}}/pack --config Release
           cpack --config ${{github.workspace}}/pack/CPackConfig.cmake -C Release -G ZIP
 
@@ -150,6 +166,10 @@ jobs:
     permissions:
       actions: write
 
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      CMAKE_ARGS: "-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.platform }}-${{ matrix.python }}-build-wheel
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -163,11 +183,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          cache: 'pip'
+
+      - name: Set up sccache
+        if: ${{ !startsWith(matrix.platform, 'ubuntu') }}
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache vcpkg binaries
+        if: ${{ !startsWith(matrix.platform, 'ubuntu') }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vcpkg/archives
+            ~/AppData/Local/vcpkg/archives
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform }}-
 
       - name: Install vcpkg
         if: ${{ !startsWith(matrix.platform, 'ubuntu') }} # vcpkg will be installed in the manylinux image for Ubuntu builds
         run: |
-          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19
+          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1
           cd vcpkg && ./bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
           echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH
@@ -217,7 +253,7 @@ jobs:
           CIBW_BEFORE_BUILD: >-
             yum install -y ninja-build gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ perl-IPC-Cmd &&
             source /opt/rh/gcc-toolset-11/enable &&
-            git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 &&
+            git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1 &&
             cd vcpkg &&
             CMAKE_POLICY_VERSION_MINIMUM=3.5 ./bootstrap-vcpkg.sh &&
             ./vcpkg integrate install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,27 @@ jobs:
     permissions:
       actions: write
 
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vcpkg/archives
+            ~/AppData/Local/vcpkg/archives
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform }}-
 
       - name: Install CMake 3.31
         if: matrix.platform != 'ubuntu-24.04-arm'
@@ -65,7 +81,7 @@ jobs:
 
       - name: Install vcpkg
         run: |
-          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19
+          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1
           cd vcpkg && ./bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
           echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH
@@ -92,12 +108,14 @@ jobs:
           cmake --preset=default -G Ninja
           -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}}
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          -DCMAKE_C_COMPILER_LAUNCHER=sccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Configure CMake
         if: ${{ !startsWith(matrix.platform, 'windows') }}
         run: |
           cmake --preset=default -DVCPKG_TARGET_TRIPLET=${{matrix.vcpkg_triplet}}
-          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
@@ -110,6 +128,8 @@ jobs:
     name: Test S3
     runs-on: ubuntu-latest
     env:
+      SCCACHE_GHA_ENABLED: "true"
+      CMAKE_ARGS: "-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
       MINIO_ROOT_USER: admin
       MINIO_ROOT_PASSWORD: password
       MINIO_URL: http://localhost:9000
@@ -123,6 +143,18 @@ jobs:
         with:
           submodules: true
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vcpkg/archives
+          key: vcpkg-ubuntu-latest-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-ubuntu-latest-
 
       - name: Install CMake 3.31
         uses: jwlawson/actions-setup-cmake@v2
@@ -151,7 +183,7 @@ jobs:
 
       - name: Install vcpkg
         run: |
-          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19
+          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1
           cd vcpkg && ./bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
           echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH
@@ -161,7 +193,7 @@ jobs:
       - name: Configure CMake
         run: |
           cmake --preset=default
-          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
@@ -198,6 +230,10 @@ jobs:
           - "macos-latest" # arm
           - "macos-15-intel" # x86_64
 
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      CMAKE_ARGS: "-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -208,10 +244,24 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13.3"
+          cache: 'pip'
+
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Cache vcpkg binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/vcpkg/archives
+            ~/AppData/Local/vcpkg/archives
+          key: vcpkg-${{ matrix.platform }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            vcpkg-${{ matrix.platform }}-
 
       - name: Install vcpkg
         run: |
-          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19
+          git clone https://github.com/microsoft/vcpkg.git -b 2025.03.19 --depth 1
           cd vcpkg && ./bootstrap-vcpkg.sh
           echo "VCPKG_ROOT=${{github.workspace}}/vcpkg" >> $GITHUB_ENV
           echo "${{github.workspace}}/vcpkg" >> $GITHUB_PATH


### PR DESCRIPTION
## Motivation

Every job across the four workflows recompiles the entire vcpkg dependency tree from source on every run — blosc, zstd, crc32c, nlohmann-json, and `minio-cpp` (which transitively pulls OpenSSL/curl). Nothing is cached between runs. On the slow `macos-15-intel` runner this regularly exhausts the 25-minute test timeout while still in the build, and it makes the 25-job wheel matrices rebuild identical C++ deps five times per platform.

## Changes (per job)

1. **vcpkg binary cache** — `actions/cache` over vcpkg''s default archive location (`~/.cache/vcpkg/archives` on Linux/macOS, `~/AppData/Local/vcpkg/archives` on Windows). Restoring prebuilt package archives skips the dependency compile entirely. This is the fix for the timeout.
   - Keyed by **platform only** + a hash of `vcpkg.json` / `vcpkg-configuration.json`, deliberately *not* by build type or Python version — so Debug/Release and all five wheel Python versions on a platform share one cache entry. vcpkg''s internal ABI hash + `restore-keys` fall back gracefully when deps are bumped.
   - Using vcpkg''s default location (which it auto-creates) avoids the `VCPKG_DEFAULT_BINARY_CACHE` + Windows-backslash-path/mkdir dance.
2. **sccache** (`mozilla-actions/sccache-action`, GitHub Actions backend) — caches the project + `minio-cpp` object files across runs. Wired via `CMAKE_<LANG>_COMPILER_LAUNCHER` on the direct-cmake jobs and via the `CMAKE_ARGS` env var (honored by scikit-build-core) on the pip-driven jobs. Ignored harmlessly by the MSVC generator where Ninja isn''t set up.
3. **Shallow vcpkg clone** (`--depth 1`) everywhere, plus `cache: pip` on `setup-python`.

## Deliberate scope limits

- **manylinux wheels get the shallow clone only.** vcpkg there is built *inside* the `cibuildwheel` container, where the runner''s cache dir and the sccache binary aren''t visible. Sharing the binary cache through the container mount is plausible but mount semantics vary by cibuildwheel version, so I left it as a follow-up rather than ship something unverified.
- **I did not cache the bootstrapped vcpkg tool tree.** Bootstrapping is ~1-2 min vs. the ~15-20 min dependency compile, and caching the full tool tree (~hundreds of MB × 5 platforms) risks evicting the high-value binary cache under the 10 GB repo cache cap. The `--depth 1` clone covers most of that win cheaply.

## Notes

- vcpkg archives and the sccache cache share the 10 GB per-repo cache budget; platform-scoped keys keep this manageable, but worth watching for eviction churn.
- Caches written on `main` are readable by PR runs, so the first post-merge run on each platform populates them and subsequent PRs get hits.
- I have not run these (no way to exercise GH Actions locally); the YAML parses and the patterns are standard, but the real validation is the first run on each platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)