### PR TITLE
Load and dump stream settings from YAML/JSON config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Load and dump stream settings from YAML or JSON config files (JSON is parsed as a subset of YAML through one path).
-  C: `ZarrStreamSettings_load_from_file`/`_load_from_string` (freed with `ZarrStreamSettings_destroy_loaded`) and
-  `ZarrStreamSettings_dump_to_file`/`_dump_to_string`. Python: `StreamSettings.from_file`/`from_string` and
-  `to_file`/`to_yaml`/`to_json`. Covers arrays, dimensions, compression, S3 endpoint, multiscale, storage dimension
-  order, and HCS plates. Credentials are never read from config. See `examples/config/`
+- Load and dump stream settings from YAML/JSON config files, via `ZarrStreamSettings_load_from_*`/`_dump_to_*` (C) and
+  `StreamSettings.from_file`/`from_string`/`from_dict`/`to_file`/`to_yaml`/`to_json`/`to_dict` (Python). Credentials are
+  never read from config. See `examples/config/` (#236)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Load and dump stream settings from YAML or JSON config files (JSON is parsed as a subset of YAML through one path).
+  C: `ZarrStreamSettings_load_from_file`/`_load_from_string` (freed with `ZarrStreamSettings_destroy_loaded`) and
+  `ZarrStreamSettings_dump_to_file`/`_dump_to_string`. Python: `StreamSettings.from_file`/`from_string` and
+  `to_file`/`to_yaml`/`to_json`. Covers arrays, dimensions, compression, S3 endpoint, multiscale, storage dimension
+  order, and HCS plates. Credentials are never read from config. See `examples/config/`
+
 ### Changed
 
 - Filesystem files are now opened with `FILE_SHARE_READ` on Windows, so another process (e.g. napari) can open the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(blosc CONFIG REQUIRED)
 #find_package(miniocpp CONFIG REQUIRED) # TODO (aliddell): uncomment when minio-cpp pushes a new release to vcpkg
 find_package(Crc32c CONFIG REQUIRED)
 find_package(zstd CONFIG REQUIRED)
+find_package(yaml-cpp CONFIG REQUIRED)
 find_package(OpenMP REQUIRED)
 
 set(CMAKE_C_STANDARD 11)

--- a/examples/config/flat.json
+++ b/examples/config/flat.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "store_path": "acquisition.zarr",
+  "overwrite": true,
+  "max_threads": 0,
+  "arrays": [
+    {
+      "output_key": "channel0",
+      "data_type": "uint16",
+      "multiscale": true,
+      "downsampling_method": "mean",
+      "max_levels": 0,
+      "compression": {
+        "compressor": "blosc1",
+        "codec": "blosc-zstd",
+        "level": 1,
+        "shuffle": 1
+      },
+      "dimensions": [
+        {"name": "t", "type": "time",  "array_size_px": 0,     "chunk_size_px": 1,   "shard_size_chunks": 1},
+        {"name": "z", "type": "space", "array_size_px": 62500, "chunk_size_px": 64,  "shard_size_chunks": 2},
+        {"name": "y", "type": "space", "array_size_px": 1200,  "chunk_size_px": 600, "shard_size_chunks": 1, "unit": "micrometer", "scale": 0.65},
+        {"name": "x", "type": "space", "array_size_px": 1920,  "chunk_size_px": 960, "shard_size_chunks": 1, "unit": "micrometer", "scale": 0.65}
+      ]
+    }
+  ]
+}

--- a/examples/config/flat.yaml
+++ b/examples/config/flat.yaml
@@ -1,0 +1,29 @@
+# Flat multi-array store loaded via ZarrStreamSettings_load_from_file /
+# StreamSettings.from_file. JSON is accepted by the same loader (see flat.json).
+# Secrets (e.g. AWS credentials) are never read from config; use the environment.
+version: 1
+store_path: acquisition.zarr
+overwrite: true
+max_threads: 0            # 0 = all available cores
+
+# s3:                     # optional; omit for filesystem
+#   endpoint: https://s3.us-west-2.amazonaws.com
+#   bucket_name: my-bucket
+#   region: us-west-2
+
+arrays:
+  - output_key: channel0
+    data_type: uint16
+    multiscale: true
+    downsampling_method: mean
+    max_levels: 0
+    compression:
+      compressor: blosc1
+      codec: blosc-zstd
+      level: 1
+      shuffle: 1
+    dimensions:
+      - {name: t, type: time,  array_size_px: 0,     chunk_size_px: 1,   shard_size_chunks: 1}
+      - {name: z, type: space, array_size_px: 62500, chunk_size_px: 64,  shard_size_chunks: 2}
+      - {name: y, type: space, array_size_px: 1200,  chunk_size_px: 600, shard_size_chunks: 1, unit: micrometer, scale: 0.65}
+      - {name: x, type: space, array_size_px: 1920,  chunk_size_px: 960, shard_size_chunks: 1, unit: micrometer, scale: 0.65}

--- a/examples/config/hcs.yaml
+++ b/examples/config/hcs.yaml
@@ -1,0 +1,26 @@
+# HCS plate store. A FieldOfView's `array` must not set output_key (its path is
+# fixed by the plate/well/fov hierarchy). Quote numeric well names so they stay
+# strings (e.g. column_name: "5").
+version: 1
+store_path: plate.zarr
+overwrite: true
+
+plates:
+  - path: test_plate
+    name: Test Plate
+    row_names: [A, B, C, D]
+    column_names: ["1", "2", "3", "4", "5"]
+    acquisitions:
+      - {id: 0, name: Meas_01, start_time: 1343731272000}
+    wells:
+      - row_name: C
+        column_name: "5"
+        images:
+          - path: fov1
+            acquisition_id: 0
+            array:
+              data_type: uint16
+              dimensions:
+                - {name: z, type: space, array_size_px: 0,   chunk_size_px: 1,   shard_size_chunks: 1}
+                - {name: y, type: space, array_size_px: 480, chunk_size_px: 256, shard_size_chunks: 4}
+                - {name: x, type: space, array_size_px: 640, chunk_size_px: 256, shard_size_chunks: 4}

--- a/include/acquire.zarr.h
+++ b/include/acquire.zarr.h
@@ -121,6 +121,67 @@ extern "C"
       char** key);
 
     /**
+     * @brief Populate stream settings from a YAML or JSON config file.
+     * @details JSON is a subset of YAML, so both formats are accepted. All
+     * arrays, dimensions, and strings referenced by @p settings are allocated
+     * and owned by the loader; free them with
+     * ZarrStreamSettings_destroy_loaded (NOT the piecemeal destroy_* functions).
+     * Secrets (e.g. AWS credentials) are never read from the file; provide them
+     * via the environment.
+     * @param[out] settings The stream settings struct to populate.
+     * @param path Path to the config file.
+     * @return ZarrStatusCode_Success on success, or an error code on failure.
+     */
+    ZarrStatusCode ZarrStreamSettings_load_from_file(
+      ZarrStreamSettings* settings,
+      const char* path);
+
+    /**
+     * @brief Populate stream settings from an in-memory YAML or JSON string.
+     * @details Ownership matches ZarrStreamSettings_load_from_file; free with
+     * ZarrStreamSettings_destroy_loaded.
+     * @param[out] settings The stream settings struct to populate.
+     * @param text The config document.
+     * @return ZarrStatusCode_Success on success, or an error code on failure.
+     */
+    ZarrStatusCode ZarrStreamSettings_load_from_string(
+      ZarrStreamSettings* settings,
+      const char* text);
+
+    /**
+     * @brief Free settings populated by ZarrStreamSettings_load_from_file or
+     * ZarrStreamSettings_load_from_string, including all loader-owned strings,
+     * arrays, dimensions, and plates.
+     * @param[in, out] settings The loader-populated stream settings struct.
+     */
+    void ZarrStreamSettings_destroy_loaded(ZarrStreamSettings* settings);
+
+    /**
+     * @brief Serialize stream settings to a config file.
+     * @details The format is chosen by the file extension: `.json` writes JSON,
+     * `.yaml`/`.yml` (or anything else) writes YAML.
+     * @param settings The stream settings struct to serialize.
+     * @param path Destination file path.
+     * @return ZarrStatusCode_Success on success, or an error code on failure.
+     */
+    ZarrStatusCode ZarrStreamSettings_dump_to_file(
+      const ZarrStreamSettings* settings,
+      const char* path);
+
+    /**
+     * @brief Serialize stream settings to a newly allocated config string.
+     * @param settings The stream settings struct to serialize.
+     * @param[out] text Set to a newly allocated string; the caller frees it
+     * (C++ callers use `free`).
+     * @param format Output format (YAML or JSON).
+     * @return ZarrStatusCode_Success on success, or an error code on failure.
+     */
+    ZarrStatusCode ZarrStreamSettings_dump_to_string(
+      const ZarrStreamSettings* settings,
+      char** text,
+      ZarrConfigFormat format);
+
+    /**
      * @brief Allocate memory for the dimension array in the Zarr array settings
      * struct.
      * @param[in, out] settings The Zarr array settings struct.

--- a/include/zarr.types.h
+++ b/include/zarr.types.h
@@ -97,6 +97,16 @@ extern "C"
     } ZarrDownsamplingMethod;
 
     /**
+     * @brief Serialization format for stream settings config files.
+     */
+    typedef enum
+    {
+        ZarrConfigFormat_Yaml = 0,
+        ZarrConfigFormat_Json,
+        ZarrConfigFormatCount,
+    } ZarrConfigFormat;
+
+    /**
      * @brief S3 settings for streaming to Zarr.
      */
     typedef struct

--- a/python/acquire-zarr-py.cpp
+++ b/python/acquire-zarr-py.cpp
@@ -2560,7 +2560,25 @@ PYBIND11_MODULE(acquire_zarr, m)
         [](const PyZarrStreamSettings& self) {
             return dump_settings(self, ZarrConfigFormat_Json);
         },
-        "Serialize stream settings to a JSON string.");
+        "Serialize stream settings to a JSON string.")
+      .def_static(
+        "from_dict",
+        [](const py::object& data) {
+            const std::string text =
+              py::module::import("json").attr("dumps")(data).cast<std::string>();
+            ZarrStreamSettings c{};
+            auto status = ZarrStreamSettings_load_from_string(&c, text.c_str());
+            return finish_load(c, status, "config dict");
+        },
+        py::arg("data"),
+        "Build stream settings from a config dict (same schema as the files).")
+      .def(
+        "to_dict",
+        [](const PyZarrStreamSettings& self) {
+            const std::string text = dump_settings(self, ZarrConfigFormat_Json);
+            return py::module::import("json").attr("loads")(text);
+        },
+        "Serialize stream settings to a config dict.");
 
     py::class_<PyZarrStream>(m, "ZarrStream")
       .def(py::init<PyZarrStreamSettings>())

--- a/python/acquire-zarr-py.cpp
+++ b/python/acquire-zarr-py.cpp
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 
@@ -1107,6 +1108,223 @@ class PyZarrStreamSettings
 
     mutable ZarrStreamSettings settings_;
 };
+
+// ---------------------------------------------------------------------------
+// Config-file support: read a loader-owned ZarrStreamSettings into Python
+// objects (the dump direction reuses to_settings() + the C dump API).
+// ---------------------------------------------------------------------------
+namespace {
+PyZarrDimensionProperties
+read_dimension(const ZarrDimensionProperties& d)
+{
+    PyZarrDimensionProperties dim;
+    dim.set_name(d.name ? d.name : "");
+    dim.set_type(d.type);
+    dim.set_array_size_px(d.array_size_px);
+    dim.set_chunk_size_px(d.chunk_size_px);
+    dim.set_shard_size_chunks(d.shard_size_chunks);
+    if (d.unit) {
+        dim.set_unit(std::string(d.unit));
+    }
+    dim.set_scale(d.scale);
+    return dim;
+}
+
+PyZarrArraySettings
+read_array(const ZarrArraySettings& a)
+{
+    PyZarrArraySettings arr;
+    if (a.output_key) {
+        arr.set_output_key(a.output_key);
+    }
+    arr.set_data_type(a.data_type);
+    // multiscale is implicit in Python: it is on iff a downsampling method is set
+    if (a.multiscale) {
+        arr.set_downsampling_method(a.downsampling_method);
+        arr.set_max_levels(a.max_levels);
+    }
+    if (a.compression_settings) {
+        PyZarrCompressionSettings c;
+        c.set_compressor(a.compression_settings->compressor);
+        c.set_codec(a.compression_settings->codec);
+        c.set_level(a.compression_settings->level);
+        c.set_shuffle(a.compression_settings->shuffle);
+        arr.set_compression(c);
+    }
+
+    std::vector<PyZarrDimensionProperties> dims;
+    dims.reserve(a.dimension_count);
+    for (size_t i = 0; i < a.dimension_count; ++i) {
+        dims.push_back(read_dimension(a.dimensions[i]));
+    }
+    arr.set_dimensions(dims);
+
+    // storage order is index-based in the config/C struct, name-based in Python
+    if (a.storage_dimension_order) {
+        std::vector<std::string> order;
+        order.reserve(a.dimension_count);
+        for (size_t i = 0; i < a.dimension_count; ++i) {
+            const size_t idx = a.storage_dimension_order[i];
+            order.push_back(idx < dims.size() ? dims[idx].name() : std::string());
+        }
+        arr.set_storage_dimension_order(order);
+    }
+    return arr;
+}
+
+PyZarrAcquisition
+read_acquisition(const ZarrHCSAcquisition& a)
+{
+    PyZarrAcquisition acq;
+    acq.set_id(a.id);
+    if (a.name) {
+        acq.set_name(std::string(a.name));
+    }
+    if (a.description) {
+        acq.set_description(std::string(a.description));
+    }
+    if (a.has_start_time) {
+        acq.set_start_time(a.start_time);
+    }
+    if (a.has_end_time) {
+        acq.set_end_time(a.end_time);
+    }
+    return acq;
+}
+
+PyZarrFieldOfView
+read_fov(const ZarrHCSFieldOfView& f)
+{
+    PyZarrFieldOfView fov;
+    fov.set_path(f.path ? f.path : "");
+    if (f.has_acquisition_id) {
+        fov.set_acquisition_id(f.acquisition_id);
+    }
+    if (f.array_settings) {
+        fov.set_array_settings(read_array(*f.array_settings));
+    }
+    return fov;
+}
+
+PyZarrWell
+read_well(const ZarrHCSWell& w)
+{
+    PyZarrWell well;
+    well.set_row_name(w.row_name ? w.row_name : "");
+    well.set_column_name(w.column_name ? w.column_name : "");
+    std::vector<PyZarrFieldOfView> images;
+    images.reserve(w.image_count);
+    for (size_t i = 0; i < w.image_count; ++i) {
+        images.push_back(read_fov(w.images[i]));
+    }
+    well.set_images(images);
+    return well;
+}
+
+PyZarrPlate
+read_plate(const ZarrHCSPlate& p)
+{
+    PyZarrPlate plate;
+    plate.set_path(p.path ? p.path : "");
+    if (p.name) {
+        plate.set_name(p.name);
+    }
+
+    std::vector<std::string> rows;
+    rows.reserve(p.row_count);
+    for (size_t i = 0; i < p.row_count; ++i) {
+        rows.emplace_back(p.row_names[i] ? p.row_names[i] : "");
+    }
+    plate.set_row_names(rows);
+
+    std::vector<std::string> cols;
+    cols.reserve(p.column_count);
+    for (size_t i = 0; i < p.column_count; ++i) {
+        cols.emplace_back(p.column_names[i] ? p.column_names[i] : "");
+    }
+    plate.set_column_names(cols);
+
+    std::vector<PyZarrAcquisition> acqs;
+    acqs.reserve(p.acquisition_count);
+    for (size_t i = 0; i < p.acquisition_count; ++i) {
+        acqs.push_back(read_acquisition(p.acquisitions[i]));
+    }
+    plate.set_acquisitions(acqs);
+
+    std::vector<PyZarrWell> wells;
+    wells.reserve(p.well_count);
+    for (size_t i = 0; i < p.well_count; ++i) {
+        wells.push_back(read_well(p.wells[i]));
+    }
+    plate.set_wells(wells);
+    return plate;
+}
+
+PyZarrStreamSettings
+read_stream_settings(const ZarrStreamSettings& s)
+{
+    PyZarrStreamSettings out;
+    out.set_store_path(s.store_path ? s.store_path : "");
+    out.set_max_threads(s.max_threads);
+    out.set_overwrite(s.overwrite);
+
+    if (s.s3_settings) {
+        PyZarrS3Settings s3;
+        s3.set_endpoint(s.s3_settings->endpoint ? s.s3_settings->endpoint : "");
+        s3.set_bucket_name(
+          s.s3_settings->bucket_name ? s.s3_settings->bucket_name : "");
+        if (s.s3_settings->region) {
+            s3.set_region(s.s3_settings->region);
+        }
+        out.set_s3(s3);
+    }
+
+    if (s.arrays) {
+        std::vector<PyZarrArraySettings> arrays;
+        arrays.reserve(s.array_count);
+        for (size_t i = 0; i < s.array_count; ++i) {
+            arrays.push_back(read_array(s.arrays[i]));
+        }
+        out.set_arrays(arrays);
+    }
+
+    if (s.hcs_settings) {
+        std::vector<PyZarrPlate> plates;
+        plates.reserve(s.hcs_settings->plate_count);
+        for (size_t i = 0; i < s.hcs_settings->plate_count; ++i) {
+            plates.push_back(read_plate(s.hcs_settings->plates[i]));
+        }
+        out.set_plates(plates);
+    }
+    return out;
+}
+
+PyZarrStreamSettings
+finish_load(ZarrStreamSettings& c, ZarrStatusCode status, const char* what)
+{
+    if (status != ZarrStatusCode_Success) {
+        ZarrStreamSettings_destroy_loaded(&c);
+        throw py::value_error(std::string("Failed to load stream settings from ") +
+                              what + " (see log for details)");
+    }
+    PyZarrStreamSettings out = read_stream_settings(c);
+    ZarrStreamSettings_destroy_loaded(&c);
+    return out;
+}
+
+std::string
+dump_settings(const PyZarrStreamSettings& self, ZarrConfigFormat format)
+{
+    char* text = nullptr;
+    if (ZarrStreamSettings_dump_to_string(self.to_settings(), &text, format) !=
+        ZarrStatusCode_Success) {
+        throw py::value_error("Failed to serialize stream settings");
+    }
+    std::string out(text);
+    free(text);
+    return out;
+}
+} // namespace
 
 class PyZarrStream
 {
@@ -2299,7 +2517,50 @@ PYBIND11_MODULE(acquire_zarr, m)
             }
             return key_list;
         },
-        "Get a list of all array output keys defined in the stream settings.");
+        "Get a list of all array output keys defined in the stream settings.")
+      .def_static(
+        "from_file",
+        [](const std::string& path) {
+            ZarrStreamSettings c{};
+            auto status = ZarrStreamSettings_load_from_file(&c, path.c_str());
+            return finish_load(c, status, "config file");
+        },
+        py::arg("path"),
+        "Load stream settings from a YAML or JSON config file.")
+      .def_static(
+        "from_string",
+        [](const std::string& text) {
+            ZarrStreamSettings c{};
+            auto status = ZarrStreamSettings_load_from_string(&c, text.c_str());
+            return finish_load(c, status, "config string");
+        },
+        py::arg("text"),
+        "Load stream settings from a YAML or JSON config string.")
+      .def(
+        "to_file",
+        [](const PyZarrStreamSettings& self, const std::string& path) {
+            if (ZarrStreamSettings_dump_to_file(self.to_settings(),
+                                                path.c_str()) !=
+                ZarrStatusCode_Success) {
+                throw py::value_error(
+                  "Failed to write stream settings to " + path);
+            }
+        },
+        py::arg("path"),
+        "Dump stream settings to a config file (format chosen by extension: "
+        "`.json` -> JSON, otherwise YAML).")
+      .def(
+        "to_yaml",
+        [](const PyZarrStreamSettings& self) {
+            return dump_settings(self, ZarrConfigFormat_Yaml);
+        },
+        "Serialize stream settings to a YAML string.")
+      .def(
+        "to_json",
+        [](const PyZarrStreamSettings& self) {
+            return dump_settings(self, ZarrConfigFormat_Json);
+        },
+        "Serialize stream settings to a JSON string.");
 
     py::class_<PyZarrStream>(m, "ZarrStream")
       .def(py::init<PyZarrStreamSettings>())

--- a/python/acquire_zarr/__init__.pyi
+++ b/python/acquire_zarr/__init__.pyi
@@ -448,6 +448,13 @@ class StreamSettings:
     def from_string(text: str) -> "StreamSettings":
         """Load stream settings from a YAML or JSON config string."""
 
+    @staticmethod
+    def from_dict(data: dict) -> "StreamSettings":
+        """Build stream settings from a config dict (same schema as files)."""
+
+    def to_dict(self) -> dict:
+        """Serialize stream settings to a config dict."""
+
     def to_file(self, path: str) -> None:
         """Dump settings to a config file (``.json`` -> JSON, else YAML)."""
 

--- a/python/acquire_zarr/__init__.pyi
+++ b/python/acquire_zarr/__init__.pyi
@@ -440,6 +440,23 @@ class StreamSettings:
     def get_array_keys(self) -> List[str]:
         """Get the list of array keys configured in this stream."""
 
+    @staticmethod
+    def from_file(path: str) -> "StreamSettings":
+        """Load stream settings from a YAML or JSON config file."""
+
+    @staticmethod
+    def from_string(text: str) -> "StreamSettings":
+        """Load stream settings from a YAML or JSON config string."""
+
+    def to_file(self, path: str) -> None:
+        """Dump settings to a config file (``.json`` -> JSON, else YAML)."""
+
+    def to_yaml(self) -> str:
+        """Serialize stream settings to a YAML string."""
+
+    def to_json(self) -> str:
+        """Serialize stream settings to a JSON string."""
+
 class Well:
     """Well configuration for HCS plate layouts.
 

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -105,6 +105,52 @@ def test_load_settings_rejects_malformed():
         )
 
 
+def test_config_dict_round_trip():
+    base = aqz.StreamSettings.from_string(CONFIG_YAML)
+
+    d = base.to_dict()
+    assert isinstance(d, dict)
+    assert d["store_path"] == "from-config.zarr"
+    assert d["arrays"][0]["data_type"] == "uint16"
+
+    _assert_expected(aqz.StreamSettings.from_dict(d))
+
+
+HCS_YAML = """
+version: 1
+store_path: plate.zarr
+plates:
+  - path: test_plate
+    name: Test Plate
+    row_names: [C]
+    column_names: ["5"]
+    wells:
+      - row_name: C
+        column_name: "5"
+        images:
+          - path: fov1
+            array:
+              data_type: uint16
+              dimensions:
+                - {name: z, type: space, array_size_px: 0,  chunk_size_px: 1,  shard_size_chunks: 1}
+                - {name: y, type: space, array_size_px: 64, chunk_size_px: 64, shard_size_chunks: 1}
+                - {name: x, type: space, array_size_px: 64, chunk_size_px: 64, shard_size_chunks: 1}
+"""
+
+
+def test_yaml_dump_quotes_ambiguous_strings():
+    s = aqz.StreamSettings.from_string(HCS_YAML)
+    assert s.hcs_plates[0].wells[0].column_name == "5"
+
+    yaml = s.to_yaml()
+    # numeric-looking names are emitted quoted so they reload as strings
+    assert '"5"' in yaml
+
+    reloaded = aqz.StreamSettings.from_string(yaml)
+    assert reloaded.hcs_plates[0].wells[0].column_name == "5"
+    assert list(reloaded.hcs_plates[0].column_names) == ["5"]
+
+
 @pytest.fixture(scope="function")
 def settings():
     return aqz.StreamSettings()

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -8,6 +8,103 @@ import acquire_zarr as aqz
 import numpy as np
 
 
+CONFIG_YAML = """
+version: 1
+store_path: from-config.zarr
+overwrite: true
+max_threads: 4
+arrays:
+  - output_key: channel0
+    data_type: uint16
+    multiscale: true
+    downsampling_method: mean
+    compression:
+      compressor: blosc1
+      codec: blosc-zstd
+      level: 1
+      shuffle: 1
+    dimensions:
+      - {name: t, type: time,  array_size_px: 0,  chunk_size_px: 1,  shard_size_chunks: 1}
+      - {name: z, type: space, array_size_px: 10, chunk_size_px: 5,  shard_size_chunks: 1}
+      - {name: y, type: space, array_size_px: 48, chunk_size_px: 16, shard_size_chunks: 1, unit: micrometer, scale: 0.5}
+      - {name: x, type: space, array_size_px: 64, chunk_size_px: 16, shard_size_chunks: 1, unit: micrometer, scale: 0.5}
+"""
+
+CONFIG_JSON = """
+{
+  "version": 1,
+  "store_path": "from-config.zarr",
+  "overwrite": true,
+  "max_threads": 4,
+  "arrays": [
+    {
+      "output_key": "channel0",
+      "data_type": "uint16",
+      "multiscale": true,
+      "downsampling_method": "mean",
+      "compression": {"compressor": "blosc1", "codec": "blosc-zstd", "level": 1, "shuffle": 1},
+      "dimensions": [
+        {"name": "t", "type": "time",  "array_size_px": 0,  "chunk_size_px": 1,  "shard_size_chunks": 1},
+        {"name": "z", "type": "space", "array_size_px": 10, "chunk_size_px": 5,  "shard_size_chunks": 1},
+        {"name": "y", "type": "space", "array_size_px": 48, "chunk_size_px": 16, "shard_size_chunks": 1, "unit": "micrometer", "scale": 0.5},
+        {"name": "x", "type": "space", "array_size_px": 64, "chunk_size_px": 16, "shard_size_chunks": 1, "unit": "micrometer", "scale": 0.5}
+      ]
+    }
+  ]
+}
+"""
+
+
+def _assert_expected(s):
+    assert s.store_path == "from-config.zarr"
+    assert s.overwrite is True
+    assert s.max_threads == 4
+    assert len(s.arrays) == 1
+    a = s.arrays[0]
+    assert a.output_key == "channel0"
+    assert a.data_type == aqz.DataType.UINT16
+    assert a.downsampling_method == aqz.DownsamplingMethod.MEAN
+    assert a.compression is not None
+    assert a.compression.compressor == aqz.Compressor.BLOSC1
+    assert a.compression.codec == aqz.CompressionCodec.BLOSC_ZSTD
+    assert a.compression.level == 1
+    assert a.compression.shuffle == 1
+    assert len(a.dimensions) == 4
+    assert a.dimensions[0].name == "t"
+    assert a.dimensions[0].kind == aqz.DimensionType.TIME
+    assert a.dimensions[2].name == "y"
+    assert a.dimensions[2].unit == "micrometer"
+    assert a.dimensions[2].scale == 0.5
+
+
+@pytest.mark.parametrize("text", [CONFIG_YAML, CONFIG_JSON])
+def test_load_settings_from_string(text):
+    _assert_expected(aqz.StreamSettings.from_string(text))
+
+
+def test_config_round_trip(tmp_path):
+    base = aqz.StreamSettings.from_string(CONFIG_YAML)
+
+    # dump -> reload through both formats
+    _assert_expected(aqz.StreamSettings.from_string(base.to_yaml()))
+    _assert_expected(aqz.StreamSettings.from_string(base.to_json()))
+
+    # dump to file (format by extension) -> reload
+    for name in ("rt.yaml", "rt.json"):
+        path = tmp_path / name
+        base.to_file(str(path))
+        _assert_expected(aqz.StreamSettings.from_file(str(path)))
+
+
+def test_load_settings_rejects_malformed():
+    with pytest.raises(ValueError):
+        aqz.StreamSettings.from_string("version: 1\nstore_path: x\n")  # no arrays
+    with pytest.raises(ValueError):
+        aqz.StreamSettings.from_string(
+            "store_path: x\narrays:\n  - data_type: float128\n    dimensions: []\n"
+        )
+
+
 @pytest.fixture(scope="function")
 def settings():
     return aqz.StreamSettings()

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -7,8 +7,8 @@ import pytest
 import acquire_zarr as aqz
 import numpy as np
 
-
-CONFIG_YAML = """
+CONFIGS = {
+    "yaml": """
 version: 1
 store_path: from-config.zarr
 overwrite: true
@@ -28,9 +28,8 @@ arrays:
       - {name: z, type: space, array_size_px: 10, chunk_size_px: 5,  shard_size_chunks: 1}
       - {name: y, type: space, array_size_px: 48, chunk_size_px: 16, shard_size_chunks: 1, unit: micrometer, scale: 0.5}
       - {name: x, type: space, array_size_px: 64, chunk_size_px: 16, shard_size_chunks: 1, unit: micrometer, scale: 0.5}
-"""
-
-CONFIG_JSON = """
+""",
+    "json": """
 {
   "version": 1,
   "store_path": "from-config.zarr",
@@ -52,103 +51,8 @@ CONFIG_JSON = """
     }
   ]
 }
-"""
-
-
-def _assert_expected(s):
-    assert s.store_path == "from-config.zarr"
-    assert s.overwrite is True
-    assert s.max_threads == 4
-    assert len(s.arrays) == 1
-    a = s.arrays[0]
-    assert a.output_key == "channel0"
-    assert a.data_type == aqz.DataType.UINT16
-    assert a.downsampling_method == aqz.DownsamplingMethod.MEAN
-    assert a.compression is not None
-    assert a.compression.compressor == aqz.Compressor.BLOSC1
-    assert a.compression.codec == aqz.CompressionCodec.BLOSC_ZSTD
-    assert a.compression.level == 1
-    assert a.compression.shuffle == 1
-    assert len(a.dimensions) == 4
-    assert a.dimensions[0].name == "t"
-    assert a.dimensions[0].kind == aqz.DimensionType.TIME
-    assert a.dimensions[2].name == "y"
-    assert a.dimensions[2].unit == "micrometer"
-    assert a.dimensions[2].scale == 0.5
-
-
-@pytest.mark.parametrize("text", [CONFIG_YAML, CONFIG_JSON])
-def test_load_settings_from_string(text):
-    _assert_expected(aqz.StreamSettings.from_string(text))
-
-
-def test_config_round_trip(tmp_path):
-    base = aqz.StreamSettings.from_string(CONFIG_YAML)
-
-    # dump -> reload through both formats
-    _assert_expected(aqz.StreamSettings.from_string(base.to_yaml()))
-    _assert_expected(aqz.StreamSettings.from_string(base.to_json()))
-
-    # dump to file (format by extension) -> reload
-    for name in ("rt.yaml", "rt.json"):
-        path = tmp_path / name
-        base.to_file(str(path))
-        _assert_expected(aqz.StreamSettings.from_file(str(path)))
-
-
-def test_load_settings_rejects_malformed():
-    with pytest.raises(ValueError):
-        aqz.StreamSettings.from_string("version: 1\nstore_path: x\n")  # no arrays
-    with pytest.raises(ValueError):
-        aqz.StreamSettings.from_string(
-            "store_path: x\narrays:\n  - data_type: float128\n    dimensions: []\n"
-        )
-
-
-def test_config_dict_round_trip():
-    base = aqz.StreamSettings.from_string(CONFIG_YAML)
-
-    d = base.to_dict()
-    assert isinstance(d, dict)
-    assert d["store_path"] == "from-config.zarr"
-    assert d["arrays"][0]["data_type"] == "uint16"
-
-    _assert_expected(aqz.StreamSettings.from_dict(d))
-
-
-HCS_YAML = """
-version: 1
-store_path: plate.zarr
-plates:
-  - path: test_plate
-    name: Test Plate
-    row_names: [C]
-    column_names: ["5"]
-    wells:
-      - row_name: C
-        column_name: "5"
-        images:
-          - path: fov1
-            array:
-              data_type: uint16
-              dimensions:
-                - {name: z, type: space, array_size_px: 0,  chunk_size_px: 1,  shard_size_chunks: 1}
-                - {name: y, type: space, array_size_px: 64, chunk_size_px: 64, shard_size_chunks: 1}
-                - {name: x, type: space, array_size_px: 64, chunk_size_px: 64, shard_size_chunks: 1}
-"""
-
-
-def test_yaml_dump_quotes_ambiguous_strings():
-    s = aqz.StreamSettings.from_string(HCS_YAML)
-    assert s.hcs_plates[0].wells[0].column_name == "5"
-
-    yaml = s.to_yaml()
-    # numeric-looking names are emitted quoted so they reload as strings
-    assert '"5"' in yaml
-
-    reloaded = aqz.StreamSettings.from_string(yaml)
-    assert reloaded.hcs_plates[0].wells[0].column_name == "5"
-    assert list(reloaded.hcs_plates[0].column_names) == ["5"]
+""",
+}
 
 
 @pytest.fixture(scope="function")
@@ -467,3 +371,100 @@ def test_estimate_max_memory_usage():
     max_memory = stream.get_maximum_memory_usage()
 
     assert max_memory == expected_memory
+
+
+def _assert_expected(s):
+    assert s.store_path == "from-config.zarr"
+    assert s.overwrite is True
+    assert s.max_threads == 4
+    assert len(s.arrays) == 1
+    a = s.arrays[0]
+    assert a.output_key == "channel0"
+    assert a.data_type == aqz.DataType.UINT16
+    assert a.downsampling_method == aqz.DownsamplingMethod.MEAN
+    assert a.compression is not None
+    assert a.compression.compressor == aqz.Compressor.BLOSC1
+    assert a.compression.codec == aqz.CompressionCodec.BLOSC_ZSTD
+    assert a.compression.level == 1
+    assert a.compression.shuffle == 1
+    assert len(a.dimensions) == 4
+    assert a.dimensions[0].name == "t"
+    assert a.dimensions[0].kind == aqz.DimensionType.TIME
+    assert a.dimensions[2].name == "y"
+    assert a.dimensions[2].unit == "micrometer"
+    assert a.dimensions[2].scale == 0.5
+
+
+@pytest.mark.parametrize("fmt", ["yaml", "json"])
+def test_load_settings_from_string(fmt):
+    _assert_expected(aqz.StreamSettings.from_string(CONFIGS[fmt]))
+
+
+def test_config_round_trip(tmp_path):
+    base = aqz.StreamSettings.from_string(CONFIGS["yaml"])
+
+    # dump -> reload through both formats
+    _assert_expected(aqz.StreamSettings.from_string(base.to_yaml()))
+    _assert_expected(aqz.StreamSettings.from_string(base.to_json()))
+
+    # dump to file (format by extension) -> reload
+    for name in ("rt.yaml", "rt.json"):
+        path = tmp_path / name
+        base.to_file(str(path))
+        _assert_expected(aqz.StreamSettings.from_file(str(path)))
+
+
+def test_load_settings_rejects_malformed():
+    with pytest.raises(ValueError):
+        aqz.StreamSettings.from_string(
+            "version: 1\nstore_path: x\n"
+        )  # no arrays
+    with pytest.raises(ValueError):
+        aqz.StreamSettings.from_string(
+            "store_path: x\narrays:\n  - data_type: float128\n    dimensions: []\n"
+        )
+
+
+def test_config_dict_round_trip():
+    base = aqz.StreamSettings.from_string(CONFIGS["yaml"])
+
+    d = base.to_dict()
+    assert isinstance(d, dict)
+    assert d["store_path"] == "from-config.zarr"
+    assert d["arrays"][0]["data_type"] == "uint16"
+
+    _assert_expected(aqz.StreamSettings.from_dict(d))
+
+
+def test_yaml_dump_quotes_ambiguous_strings():
+    hcs_yaml = """
+version: 1
+store_path: plate.zarr
+plates:
+  - path: test_plate
+    name: Test Plate
+    row_names: [C]
+    column_names: ["5"]
+    wells:
+      - row_name: C
+        column_name: "5"
+        images:
+          - path: fov1
+            array:
+              data_type: uint16
+              dimensions:
+                - {name: z, type: space, array_size_px: 0,  chunk_size_px: 1,  shard_size_chunks: 1}
+                - {name: y, type: space, array_size_px: 64, chunk_size_px: 64, shard_size_chunks: 1}
+                - {name: x, type: space, array_size_px: 64, chunk_size_px: 64, shard_size_chunks: 1}
+"""
+
+    s = aqz.StreamSettings.from_string(hcs_yaml)
+    assert s.hcs_plates[0].wells[0].column_name == "5"
+
+    yaml = s.to_yaml()
+    # numeric-looking names are emitted quoted so they reload as strings
+    assert '"5"' in yaml
+
+    reloaded = aqz.StreamSettings.from_string(yaml)
+    assert reloaded.hcs_plates[0].wells[0].column_name == "5"
+    assert list(reloaded.hcs_plates[0].column_names) == ["5"]

--- a/src/streaming/CMakeLists.txt
+++ b/src/streaming/CMakeLists.txt
@@ -9,6 +9,8 @@ endif ()
 add_library(${tgt}
         macros.hh
         acquire.zarr.cpp
+        settings.io.hh
+        settings.io.cpp
         array.dimensions.hh
         array.dimensions.cpp
         frame.queue.hh
@@ -64,6 +66,8 @@ target_link_libraries(${tgt} PRIVATE
         blosc_static
         miniocpp::miniocpp
         Crc32c::crc32c
+        nlohmann_json::nlohmann_json
+        yaml-cpp::yaml-cpp
         $<IF:$<TARGET_EXISTS:zstd::libzstd_static>,zstd::libzstd_static,zstd::libzstd_shared>
         OpenMP::OpenMP_CXX
 )

--- a/src/streaming/settings.io.cpp
+++ b/src/streaming/settings.io.cpp
@@ -14,7 +14,8 @@
 using json = nlohmann::json;
 
 // ---------------------------------------------------------------------------
-// YAML <-> JSON bridge (JSON is a subset of YAML, so one parse path serves both)
+// YAML <-> JSON bridge (JSON is a subset of YAML, so one parse path serves
+// both)
 // ---------------------------------------------------------------------------
 namespace {
 json
@@ -26,7 +27,8 @@ scalar_to_json(const YAML::Node& node)
     }
 
     // Strict JSON-style booleans only. yaml-cpp follows YAML 1.1, where y/yes/
-    // no/on/off are booleans -- that would turn a dimension named "y" into true.
+    // no/on/off are booleans -- that would turn a dimension named "y" into
+    // true.
     if (s == "true") {
         return true;
     }
@@ -78,44 +80,80 @@ yaml_to_json(const YAML::Node& node)
     return nullptr;
 }
 
-YAML::Node
-json_to_yaml_node(const json& doc)
+// A string needs quoting on emit iff loading it back would not yield a string
+// (mirrors scalar_to_json). Otherwise a well named "5" would round-trip to int.
+bool
+reparses_as_nonstring(const std::string& s)
 {
-    YAML::Node node;
+    if (s == "true" || s == "false") {
+        return true;
+    }
+    if (s.empty() || s == "~" || s == "null") {
+        return true;
+    }
+    const YAML::Node n(s);
+
+    if (int64_t i; YAML::convert<int64_t>::decode(n, i)) {
+        return true;
+    }
+
+    if (uint64_t u; YAML::convert<uint64_t>::decode(n, u)) {
+        return true;
+    }
+
+    if (double d; YAML::convert<double>::decode(n, d)) {
+        return true;
+    }
+
+    return false;
+}
+
+void
+emit_json(YAML::Emitter& e, const json& doc)
+{
     switch (doc.type()) {
-        case json::value_t::null:
-            node = YAML::Node(YAML::NodeType::Null);
-            break;
         case json::value_t::object:
+            e << YAML::BeginMap;
             for (const auto& [key, value] : doc.items()) {
-                node[key] = json_to_yaml_node(value);
+                e << YAML::Key << key << YAML::Value;
+                emit_json(e, value);
             }
+            e << YAML::EndMap;
             break;
         case json::value_t::array:
+            e << YAML::BeginSeq;
             for (const auto& value : doc) {
-                node.push_back(json_to_yaml_node(value));
+                emit_json(e, value);
             }
+            e << YAML::EndSeq;
             break;
-        case json::value_t::string:
-            node = doc.get<std::string>();
+        case json::value_t::string: {
+            const auto s = doc.get<std::string>();
+            if (reparses_as_nonstring(s)) {
+                e << YAML::DoubleQuoted; // one-shot: applies to the next scalar
+            }
+            e << s;
             break;
+        }
         case json::value_t::boolean:
-            node = doc.get<bool>();
+            e << doc.get<bool>();
             break;
         case json::value_t::number_integer:
-            node = doc.get<int64_t>();
+            e << doc.get<int64_t>();
             break;
         case json::value_t::number_unsigned:
-            node = doc.get<uint64_t>();
+            e << doc.get<uint64_t>();
             break;
         case json::value_t::number_float:
-            node = doc.get<double>();
+            e << doc.get<double>();
+            break;
+        case json::value_t::null:
+            e << YAML::Null;
             break;
         default:
-            node = doc.dump();
+            e << doc.dump();
             break;
     }
-    return node;
 }
 } // namespace
 
@@ -131,7 +169,7 @@ struct EnumEntry
     int value;
 };
 
-const EnumEntry kDataTypes[] = {
+constexpr EnumEntry kDataTypes[] = {
     { "uint8", ZarrDataType_uint8 },     { "uint16", ZarrDataType_uint16 },
     { "uint32", ZarrDataType_uint32 },   { "uint64", ZarrDataType_uint64 },
     { "int8", ZarrDataType_int8 },       { "int16", ZarrDataType_int16 },
@@ -139,27 +177,27 @@ const EnumEntry kDataTypes[] = {
     { "float32", ZarrDataType_float32 }, { "float64", ZarrDataType_float64 },
 };
 
-const EnumEntry kDimensionTypes[] = {
+constexpr EnumEntry kDimensionTypes[] = {
     { "space", ZarrDimensionType_Space },
     { "channel", ZarrDimensionType_Channel },
     { "time", ZarrDimensionType_Time },
     { "other", ZarrDimensionType_Other },
 };
 
-const EnumEntry kCompressors[] = {
+constexpr EnumEntry kCompressors[] = {
     { "none", ZarrCompressor_None },
     { "blosc1", ZarrCompressor_Blosc1 },
     { "zstd", ZarrCompressor_Zstd },
 };
 
-const EnumEntry kCodecs[] = {
+constexpr EnumEntry kCodecs[] = {
     { "none", ZarrCompressionCodec_None },
     { "blosc-lz4", ZarrCompressionCodec_BloscLZ4 },
     { "blosc-zstd", ZarrCompressionCodec_BloscZstd },
     { "zstd", ZarrCompressionCodec_Zstd },
 };
 
-const EnumEntry kDownsamplingMethods[] = {
+constexpr EnumEntry kDownsamplingMethods[] = {
     { "decimate", ZarrDownsamplingMethod_Decimate },
     { "mean", ZarrDownsamplingMethod_Mean },
     { "min", ZarrDownsamplingMethod_Min },
@@ -187,8 +225,8 @@ from_enum(const EnumEntry (&table)[N], int value, const char* what)
             return e.name;
         }
     }
-    throw std::runtime_error("unmappable " + std::string(what) + " value: " +
-                             std::to_string(value));
+    throw std::runtime_error("unmappable " + std::string(what) +
+                             " value: " + std::to_string(value));
 }
 
 [[noreturn]] void
@@ -318,42 +356,59 @@ alloc_zeroed(size_t n)
 // ---------------------------------------------------------------------------
 namespace {
 void
-load_dimension(const json& j, ZarrDimensionProperties* dim, const std::string& ctx)
+load_dimension(const json& j,
+               ZarrDimensionProperties* dim,
+               const std::string& ctx)
 {
     dim->name = dup_cstr(as_string(require(j, "name", ctx), ctx + ".name"));
-    dim->type = static_cast<ZarrDimensionType>(to_enum(
-      kDimensionTypes, as_string(require(j, "type", ctx), ctx + ".type"), "dimension type"));
-    dim->array_size_px = as_u32(require(j, "array_size_px", ctx), ctx + ".array_size_px");
-    dim->chunk_size_px = as_u32(require(j, "chunk_size_px", ctx), ctx + ".chunk_size_px");
+    dim->type = static_cast<ZarrDimensionType>(
+      to_enum(kDimensionTypes,
+              as_string(require(j, "type", ctx), ctx + ".type"),
+              "dimension type"));
+    dim->array_size_px =
+      as_u32(require(j, "array_size_px", ctx), ctx + ".array_size_px");
+    dim->chunk_size_px =
+      as_u32(require(j, "chunk_size_px", ctx), ctx + ".chunk_size_px");
     dim->shard_size_chunks =
       as_u32(require(j, "shard_size_chunks", ctx), ctx + ".shard_size_chunks");
 
     if (j.contains("unit") && !j.at("unit").is_null()) {
         dim->unit = dup_cstr(as_string(j.at("unit"), ctx + ".unit"));
     }
-    dim->scale = j.contains("scale") ? as_double(j.at("scale"), ctx + ".scale") : 1.0;
+    dim->scale =
+      j.contains("scale") ? as_double(j.at("scale"), ctx + ".scale") : 1.0;
 }
 
 void
-load_array(const json& j, ZarrArraySettings* arr, const std::string& ctx, bool allow_output_key)
+load_array(const json& j,
+           ZarrArraySettings* arr,
+           const std::string& ctx,
+           bool allow_output_key)
 {
-    if (allow_output_key && j.contains("output_key") && !j.at("output_key").is_null()) {
-        arr->output_key = dup_cstr(as_string(j.at("output_key"), ctx + ".output_key"));
+    if (allow_output_key && j.contains("output_key") &&
+        !j.at("output_key").is_null()) {
+        arr->output_key =
+          dup_cstr(as_string(j.at("output_key"), ctx + ".output_key"));
     }
 
-    arr->data_type = static_cast<ZarrDataType>(to_enum(
-      kDataTypes, as_string(require(j, "data_type", ctx), ctx + ".data_type"), "data type"));
+    arr->data_type = static_cast<ZarrDataType>(
+      to_enum(kDataTypes,
+              as_string(require(j, "data_type", ctx), ctx + ".data_type"),
+              "data type"));
 
-    arr->multiscale =
-      j.contains("multiscale") ? as_bool(j.at("multiscale"), ctx + ".multiscale") : false;
+    arr->multiscale = j.contains("multiscale")
+                        ? as_bool(j.at("multiscale"), ctx + ".multiscale")
+                        : false;
     arr->downsampling_method = static_cast<ZarrDownsamplingMethod>(
       j.contains("downsampling_method")
         ? to_enum(kDownsamplingMethods,
-                  as_string(j.at("downsampling_method"), ctx + ".downsampling_method"),
+                  as_string(j.at("downsampling_method"),
+                            ctx + ".downsampling_method"),
                   "downsampling method")
         : ZarrDownsamplingMethod_Decimate);
-    arr->max_levels =
-      j.contains("max_levels") ? as_u32(j.at("max_levels"), ctx + ".max_levels") : 0;
+    arr->max_levels = j.contains("max_levels")
+                        ? as_u32(j.at("max_levels"), ctx + ".max_levels")
+                        : 0;
 
     if (j.contains("compression") && !j.at("compression").is_null()) {
         const auto& c = j.at("compression");
@@ -361,15 +416,21 @@ load_array(const json& j, ZarrArraySettings* arr, const std::string& ctx, bool a
         auto* cs = alloc_zeroed<ZarrCompressionSettings>(1);
         arr->compression_settings = cs;
         cs->compressor = static_cast<ZarrCompressor>(to_enum(
-          kCompressors, as_string(require(c, "compressor", cctx), cctx + ".compressor"),
+          kCompressors,
+          as_string(require(c, "compressor", cctx), cctx + ".compressor"),
           "compressor"));
-        cs->codec = static_cast<ZarrCompressionCodec>(to_enum(
-          kCodecs, as_string(require(c, "codec", cctx), cctx + ".codec"), "codec"));
+        cs->codec = static_cast<ZarrCompressionCodec>(
+          to_enum(kCodecs,
+                  as_string(require(c, "codec", cctx), cctx + ".codec"),
+                  "codec"));
         cs->level =
-          c.contains("level") ? static_cast<uint8_t>(as_u32(c.at("level"), cctx + ".level")) : 0;
-        cs->shuffle = c.contains("shuffle")
-                        ? static_cast<uint8_t>(as_u32(c.at("shuffle"), cctx + ".shuffle"))
-                        : 0;
+          c.contains("level")
+            ? static_cast<uint8_t>(as_u32(c.at("level"), cctx + ".level"))
+            : 0;
+        cs->shuffle =
+          c.contains("shuffle")
+            ? static_cast<uint8_t>(as_u32(c.at("shuffle"), cctx + ".shuffle"))
+            : 0;
     }
 
     const auto& dims = require(j, "dimensions", ctx);
@@ -379,8 +440,9 @@ load_array(const json& j, ZarrArraySettings* arr, const std::string& ctx, bool a
     arr->dimension_count = dims.size();
     arr->dimensions = alloc_zeroed<ZarrDimensionProperties>(dims.size());
     for (size_t i = 0; i < dims.size(); ++i) {
-        load_dimension(
-          dims[i], &arr->dimensions[i], ctx + ".dimensions[" + std::to_string(i) + "]");
+        load_dimension(dims[i],
+                       &arr->dimensions[i],
+                       ctx + ".dimensions[" + std::to_string(i) + "]");
     }
 
     if (j.contains("storage_dimension_order") &&
@@ -407,7 +469,8 @@ load_acquisition(const json& j, ZarrHCSAcquisition* acq, const std::string& ctx)
         acq->name = dup_cstr(as_string(j.at("name"), ctx + ".name"));
     }
     if (j.contains("description") && !j.at("description").is_null()) {
-        acq->description = dup_cstr(as_string(j.at("description"), ctx + ".description"));
+        acq->description =
+          dup_cstr(as_string(j.at("description"), ctx + ".description"));
     }
     if (j.contains("start_time") && !j.at("start_time").is_null()) {
         acq->start_time = as_u64(j.at("start_time"), ctx + ".start_time");
@@ -424,17 +487,20 @@ load_fov(const json& j, ZarrHCSFieldOfView* fov, const std::string& ctx)
 {
     fov->path = dup_cstr(as_string(require(j, "path", ctx), ctx + ".path"));
     if (j.contains("acquisition_id") && !j.at("acquisition_id").is_null()) {
-        fov->acquisition_id = as_u32(j.at("acquisition_id"), ctx + ".acquisition_id");
+        fov->acquisition_id =
+          as_u32(j.at("acquisition_id"), ctx + ".acquisition_id");
         fov->has_acquisition_id = true;
     }
     fov->array_settings = alloc_zeroed<ZarrArraySettings>(1);
-    load_array(require(j, "array", ctx), fov->array_settings, ctx + ".array", false);
+    load_array(
+      require(j, "array", ctx), fov->array_settings, ctx + ".array", false);
 }
 
 void
 load_well(const json& j, ZarrHCSWell* well, const std::string& ctx)
 {
-    well->row_name = dup_cstr(as_string(require(j, "row_name", ctx), ctx + ".row_name"));
+    well->row_name =
+      dup_cstr(as_string(require(j, "row_name", ctx), ctx + ".row_name"));
     well->column_name =
       dup_cstr(as_string(require(j, "column_name", ctx), ctx + ".column_name"));
 
@@ -445,7 +511,9 @@ load_well(const json& j, ZarrHCSWell* well, const std::string& ctx)
     well->image_count = images.size();
     well->images = alloc_zeroed<ZarrHCSFieldOfView>(images.size());
     for (size_t i = 0; i < images.size(); ++i) {
-        load_fov(images[i], &well->images[i], ctx + ".images[" + std::to_string(i) + "]");
+        load_fov(images[i],
+                 &well->images[i],
+                 ctx + ".images[" + std::to_string(i) + "]");
     }
 }
 
@@ -481,7 +549,8 @@ load_plate(const json& j, ZarrHCSPlate* plate, const std::string& ctx)
         plate->name = dup_cstr(as_string(j.at("name"), ctx + ".name"));
     }
 
-    const auto rows = as_string_list(require(j, "row_names", ctx), ctx + ".row_names");
+    const auto rows =
+      as_string_list(require(j, "row_names", ctx), ctx + ".row_names");
     plate->row_count = rows.size();
     plate->row_names = dup_string_list(rows);
 
@@ -497,7 +566,9 @@ load_plate(const json& j, ZarrHCSPlate* plate, const std::string& ctx)
     plate->well_count = wells.size();
     plate->wells = alloc_zeroed<ZarrHCSWell>(wells.size());
     for (size_t i = 0; i < wells.size(); ++i) {
-        load_well(wells[i], &plate->wells[i], ctx + ".wells[" + std::to_string(i) + "]");
+        load_well(wells[i],
+                  &plate->wells[i],
+                  ctx + ".wells[" + std::to_string(i) + "]");
     }
 
     if (j.contains("acquisitions") && !j.at("acquisitions").is_null()) {
@@ -546,14 +617,15 @@ dump_array(const ZarrArraySettings& a, bool include_output_key)
     j["data_type"] = from_enum(kDataTypes, a.data_type, "data type");
     j["multiscale"] = a.multiscale;
     if (a.multiscale) {
-        j["downsampling_method"] =
-          from_enum(kDownsamplingMethods, a.downsampling_method, "downsampling method");
+        j["downsampling_method"] = from_enum(
+          kDownsamplingMethods, a.downsampling_method, "downsampling method");
         j["max_levels"] = a.max_levels;
     }
     if (a.compression_settings) {
         const auto& c = *a.compression_settings;
         j["compression"] = {
-            { "compressor", from_enum(kCompressors, c.compressor, "compressor") },
+            { "compressor",
+              from_enum(kCompressors, c.compressor, "compressor") },
             { "codec", from_enum(kCodecs, c.codec, "codec") },
             { "level", c.level },
             { "shuffle", c.shuffle },
@@ -650,7 +722,7 @@ std::string
 json_to_yaml(const json& doc)
 {
     YAML::Emitter emitter;
-    emitter << json_to_yaml_node(doc);
+    emit_json(emitter, doc);
     return emitter.c_str();
 }
 
@@ -668,25 +740,29 @@ json_to_settings(const json& doc, ZarrStreamSettings* out)
         const auto v = as_u64(doc.at("version"), "version");
         if (v != kSchemaVersion) {
             fail("version",
-                 "unsupported schema version " + std::to_string(v) + " (expected " +
-                   std::to_string(kSchemaVersion) + ")");
+                 "unsupported schema version " + std::to_string(v) +
+                   " (expected " + std::to_string(kSchemaVersion) + ")");
         }
     }
 
-    out->store_path = dup_cstr(as_string(require(doc, "store_path", ""), "store_path"));
-    out->overwrite = doc.contains("overwrite") ? as_bool(doc.at("overwrite"), "overwrite") : false;
-    out->max_threads =
-      doc.contains("max_threads")
-        ? static_cast<unsigned int>(as_u32(doc.at("max_threads"), "max_threads"))
-        : 0;
+    out->store_path =
+      dup_cstr(as_string(require(doc, "store_path", ""), "store_path"));
+    out->overwrite = doc.contains("overwrite")
+                       ? as_bool(doc.at("overwrite"), "overwrite")
+                       : false;
+    out->max_threads = doc.contains("max_threads")
+                         ? static_cast<unsigned int>(
+                             as_u32(doc.at("max_threads"), "max_threads"))
+                         : 0;
 
     if (doc.contains("s3") && !doc.at("s3").is_null()) {
         const auto& s = doc.at("s3");
         auto* s3 = alloc_zeroed<ZarrS3Settings>(1);
         out->s3_settings = s3;
-        s3->endpoint = dup_cstr(as_string(require(s, "endpoint", "s3"), "s3.endpoint"));
-        s3->bucket_name =
-          dup_cstr(as_string(require(s, "bucket_name", "s3"), "s3.bucket_name"));
+        s3->endpoint =
+          dup_cstr(as_string(require(s, "endpoint", "s3"), "s3.endpoint"));
+        s3->bucket_name = dup_cstr(
+          as_string(require(s, "bucket_name", "s3"), "s3.bucket_name"));
         if (s.contains("region") && !s.at("region").is_null()) {
             s3->region = dup_cstr(as_string(s.at("region"), "s3.region"));
         }
@@ -700,8 +776,10 @@ json_to_settings(const json& doc, ZarrStreamSettings* out)
         out->array_count = arrays.size();
         out->arrays = alloc_zeroed<ZarrArraySettings>(arrays.size());
         for (size_t i = 0; i < arrays.size(); ++i) {
-            load_array(
-              arrays[i], &out->arrays[i], "arrays[" + std::to_string(i) + "]", true);
+            load_array(arrays[i],
+                       &out->arrays[i],
+                       "arrays[" + std::to_string(i) + "]",
+                       true);
         }
     }
 
@@ -867,7 +945,8 @@ load_from(const std::string& text, ZarrStreamSettings* settings)
         zarr::json_to_settings(zarr::config_text_to_json(text), settings);
     } catch (const std::exception& exc) {
         LOG_ERROR("Failed to load settings: ", exc.what());
-        zarr::destroy_loaded_settings(settings); // release any partial allocation
+        zarr::destroy_loaded_settings(
+          settings); // release any partial allocation
         return ZarrStatusCode_InvalidSettings;
     }
     return ZarrStatusCode_Success;
@@ -945,8 +1024,9 @@ extern "C"
 
         try {
             const auto doc = zarr::settings_to_json(settings);
-            const std::string out =
-              format == ZarrConfigFormat_Json ? doc.dump(2) : zarr::json_to_yaml(doc);
+            const std::string out = format == ZarrConfigFormat_Json
+                                      ? doc.dump(2)
+                                      : zarr::json_to_yaml(doc);
 
             auto* buf = static_cast<char*>(std::malloc(out.size() + 1));
             if (!buf) {

--- a/src/streaming/settings.io.cpp
+++ b/src/streaming/settings.io.cpp
@@ -1,0 +1,963 @@
+#include "settings.io.hh"
+#include "acquire.zarr.h"
+#include "macros.hh"
+
+#include <yaml-cpp/yaml.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+using json = nlohmann::json;
+
+// ---------------------------------------------------------------------------
+// YAML <-> JSON bridge (JSON is a subset of YAML, so one parse path serves both)
+// ---------------------------------------------------------------------------
+namespace {
+json
+scalar_to_json(const YAML::Node& node)
+{
+    const auto& s = node.Scalar();
+    if (node.Tag() == "tag:yaml.org,2002:str") {
+        return s; // explicitly tagged string, e.g. a numeric well name
+    }
+
+    // Strict JSON-style booleans only. yaml-cpp follows YAML 1.1, where y/yes/
+    // no/on/off are booleans -- that would turn a dimension named "y" into true.
+    if (s == "true") {
+        return true;
+    }
+    if (s == "false") {
+        return false;
+    }
+    int64_t i;
+    if (YAML::convert<int64_t>::decode(node, i)) {
+        return i;
+    }
+    uint64_t u;
+    if (YAML::convert<uint64_t>::decode(node, u)) {
+        return u;
+    }
+    double d;
+    if (YAML::convert<double>::decode(node, d)) {
+        return d;
+    }
+    if (s.empty() || s == "~" || s == "null") {
+        return nullptr;
+    }
+    return s;
+}
+
+json
+yaml_to_json(const YAML::Node& node)
+{
+    switch (node.Type()) {
+        case YAML::NodeType::Null:
+        case YAML::NodeType::Undefined:
+            return nullptr;
+        case YAML::NodeType::Scalar:
+            return scalar_to_json(node);
+        case YAML::NodeType::Sequence: {
+            auto arr = json::array();
+            for (const auto& child : node) {
+                arr.push_back(yaml_to_json(child));
+            }
+            return arr;
+        }
+        case YAML::NodeType::Map: {
+            auto obj = json::object();
+            for (const auto& kv : node) {
+                obj[kv.first.as<std::string>()] = yaml_to_json(kv.second);
+            }
+            return obj;
+        }
+    }
+    return nullptr;
+}
+
+YAML::Node
+json_to_yaml_node(const json& doc)
+{
+    YAML::Node node;
+    switch (doc.type()) {
+        case json::value_t::null:
+            node = YAML::Node(YAML::NodeType::Null);
+            break;
+        case json::value_t::object:
+            for (const auto& [key, value] : doc.items()) {
+                node[key] = json_to_yaml_node(value);
+            }
+            break;
+        case json::value_t::array:
+            for (const auto& value : doc) {
+                node.push_back(json_to_yaml_node(value));
+            }
+            break;
+        case json::value_t::string:
+            node = doc.get<std::string>();
+            break;
+        case json::value_t::boolean:
+            node = doc.get<bool>();
+            break;
+        case json::value_t::number_integer:
+            node = doc.get<int64_t>();
+            break;
+        case json::value_t::number_unsigned:
+            node = doc.get<uint64_t>();
+            break;
+        case json::value_t::number_float:
+            node = doc.get<double>();
+            break;
+        default:
+            node = doc.dump();
+            break;
+    }
+    return node;
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Schema version, enum tables, and typed JSON accessors
+// ---------------------------------------------------------------------------
+namespace {
+constexpr int kSchemaVersion = 1;
+
+struct EnumEntry
+{
+    const char* name;
+    int value;
+};
+
+const EnumEntry kDataTypes[] = {
+    { "uint8", ZarrDataType_uint8 },     { "uint16", ZarrDataType_uint16 },
+    { "uint32", ZarrDataType_uint32 },   { "uint64", ZarrDataType_uint64 },
+    { "int8", ZarrDataType_int8 },       { "int16", ZarrDataType_int16 },
+    { "int32", ZarrDataType_int32 },     { "int64", ZarrDataType_int64 },
+    { "float32", ZarrDataType_float32 }, { "float64", ZarrDataType_float64 },
+};
+
+const EnumEntry kDimensionTypes[] = {
+    { "space", ZarrDimensionType_Space },
+    { "channel", ZarrDimensionType_Channel },
+    { "time", ZarrDimensionType_Time },
+    { "other", ZarrDimensionType_Other },
+};
+
+const EnumEntry kCompressors[] = {
+    { "none", ZarrCompressor_None },
+    { "blosc1", ZarrCompressor_Blosc1 },
+    { "zstd", ZarrCompressor_Zstd },
+};
+
+const EnumEntry kCodecs[] = {
+    { "none", ZarrCompressionCodec_None },
+    { "blosc-lz4", ZarrCompressionCodec_BloscLZ4 },
+    { "blosc-zstd", ZarrCompressionCodec_BloscZstd },
+    { "zstd", ZarrCompressionCodec_Zstd },
+};
+
+const EnumEntry kDownsamplingMethods[] = {
+    { "decimate", ZarrDownsamplingMethod_Decimate },
+    { "mean", ZarrDownsamplingMethod_Mean },
+    { "min", ZarrDownsamplingMethod_Min },
+    { "max", ZarrDownsamplingMethod_Max },
+};
+
+template<size_t N>
+int
+to_enum(const EnumEntry (&table)[N], const std::string& s, const char* what)
+{
+    for (const auto& e : table) {
+        if (s == e.name) {
+            return e.value;
+        }
+    }
+    throw std::runtime_error("invalid " + std::string(what) + ": '" + s + "'");
+}
+
+template<size_t N>
+const char*
+from_enum(const EnumEntry (&table)[N], int value, const char* what)
+{
+    for (const auto& e : table) {
+        if (value == e.value) {
+            return e.name;
+        }
+    }
+    throw std::runtime_error("unmappable " + std::string(what) + " value: " +
+                             std::to_string(value));
+}
+
+[[noreturn]] void
+fail(const std::string& ctx, const std::string& msg)
+{
+    throw std::runtime_error(ctx.empty() ? msg : ctx + ": " + msg);
+}
+
+const json&
+require(const json& obj, const char* key, const std::string& ctx)
+{
+    if (!obj.is_object() || !obj.contains(key)) {
+        fail(ctx, "missing required field '" + std::string(key) + "'");
+    }
+    return obj.at(key);
+}
+
+std::string
+as_string(const json& j, const std::string& ctx)
+{
+    if (j.is_string()) {
+        return j.get<std::string>();
+    }
+    if (j.is_number_unsigned()) {
+        return std::to_string(j.get<uint64_t>());
+    }
+    if (j.is_number_integer()) {
+        return std::to_string(j.get<int64_t>());
+    }
+    if (j.is_boolean()) {
+        return j.get<bool>() ? "true" : "false";
+    }
+    fail(ctx, "expected a string");
+}
+
+uint64_t
+as_u64(const json& j, const std::string& ctx)
+{
+    if (j.is_number_unsigned()) {
+        return j.get<uint64_t>();
+    }
+    if (j.is_number_integer()) {
+        const auto v = j.get<int64_t>();
+        if (v < 0) {
+            fail(ctx, "expected a non-negative integer");
+        }
+        return static_cast<uint64_t>(v);
+    }
+    if (j.is_string()) {
+        try {
+            return std::stoull(j.get<std::string>());
+        } catch (...) {
+            fail(ctx, "expected an integer");
+        }
+    }
+    fail(ctx, "expected an integer");
+}
+
+uint32_t
+as_u32(const json& j, const std::string& ctx)
+{
+    return static_cast<uint32_t>(as_u64(j, ctx));
+}
+
+bool
+as_bool(const json& j, const std::string& ctx)
+{
+    if (j.is_boolean()) {
+        return j.get<bool>();
+    }
+    fail(ctx, "expected a boolean");
+}
+
+double
+as_double(const json& j, const std::string& ctx)
+{
+    if (j.is_number()) {
+        return j.get<double>();
+    }
+    if (j.is_string()) {
+        try {
+            return std::stod(j.get<std::string>());
+        } catch (...) {
+            fail(ctx, "expected a number");
+        }
+    }
+    fail(ctx, "expected a number");
+}
+
+// ---------------------------------------------------------------------------
+// Owning allocation helpers (freed by destroy_loaded_settings)
+// ---------------------------------------------------------------------------
+char*
+dup_cstr(const std::string& s)
+{
+    auto* p = static_cast<char*>(std::malloc(s.size() + 1));
+    if (!p) {
+        throw std::bad_alloc();
+    }
+    std::memcpy(p, s.c_str(), s.size() + 1);
+    return p;
+}
+
+void
+free_cstr(const char* p)
+{
+    std::free(const_cast<char*>(p));
+}
+
+template<typename T>
+T*
+alloc_zeroed(size_t n)
+{
+    if (n == 0) {
+        return nullptr;
+    }
+    auto* p = static_cast<T*>(std::calloc(n, sizeof(T)));
+    if (!p) {
+        throw std::bad_alloc();
+    }
+    return p;
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// JSON -> settings (owning)
+// ---------------------------------------------------------------------------
+namespace {
+void
+load_dimension(const json& j, ZarrDimensionProperties* dim, const std::string& ctx)
+{
+    dim->name = dup_cstr(as_string(require(j, "name", ctx), ctx + ".name"));
+    dim->type = static_cast<ZarrDimensionType>(to_enum(
+      kDimensionTypes, as_string(require(j, "type", ctx), ctx + ".type"), "dimension type"));
+    dim->array_size_px = as_u32(require(j, "array_size_px", ctx), ctx + ".array_size_px");
+    dim->chunk_size_px = as_u32(require(j, "chunk_size_px", ctx), ctx + ".chunk_size_px");
+    dim->shard_size_chunks =
+      as_u32(require(j, "shard_size_chunks", ctx), ctx + ".shard_size_chunks");
+
+    if (j.contains("unit") && !j.at("unit").is_null()) {
+        dim->unit = dup_cstr(as_string(j.at("unit"), ctx + ".unit"));
+    }
+    dim->scale = j.contains("scale") ? as_double(j.at("scale"), ctx + ".scale") : 1.0;
+}
+
+void
+load_array(const json& j, ZarrArraySettings* arr, const std::string& ctx, bool allow_output_key)
+{
+    if (allow_output_key && j.contains("output_key") && !j.at("output_key").is_null()) {
+        arr->output_key = dup_cstr(as_string(j.at("output_key"), ctx + ".output_key"));
+    }
+
+    arr->data_type = static_cast<ZarrDataType>(to_enum(
+      kDataTypes, as_string(require(j, "data_type", ctx), ctx + ".data_type"), "data type"));
+
+    arr->multiscale =
+      j.contains("multiscale") ? as_bool(j.at("multiscale"), ctx + ".multiscale") : false;
+    arr->downsampling_method = static_cast<ZarrDownsamplingMethod>(
+      j.contains("downsampling_method")
+        ? to_enum(kDownsamplingMethods,
+                  as_string(j.at("downsampling_method"), ctx + ".downsampling_method"),
+                  "downsampling method")
+        : ZarrDownsamplingMethod_Decimate);
+    arr->max_levels =
+      j.contains("max_levels") ? as_u32(j.at("max_levels"), ctx + ".max_levels") : 0;
+
+    if (j.contains("compression") && !j.at("compression").is_null()) {
+        const auto& c = j.at("compression");
+        const auto cctx = ctx + ".compression";
+        auto* cs = alloc_zeroed<ZarrCompressionSettings>(1);
+        arr->compression_settings = cs;
+        cs->compressor = static_cast<ZarrCompressor>(to_enum(
+          kCompressors, as_string(require(c, "compressor", cctx), cctx + ".compressor"),
+          "compressor"));
+        cs->codec = static_cast<ZarrCompressionCodec>(to_enum(
+          kCodecs, as_string(require(c, "codec", cctx), cctx + ".codec"), "codec"));
+        cs->level =
+          c.contains("level") ? static_cast<uint8_t>(as_u32(c.at("level"), cctx + ".level")) : 0;
+        cs->shuffle = c.contains("shuffle")
+                        ? static_cast<uint8_t>(as_u32(c.at("shuffle"), cctx + ".shuffle"))
+                        : 0;
+    }
+
+    const auto& dims = require(j, "dimensions", ctx);
+    if (!dims.is_array() || dims.empty()) {
+        fail(ctx + ".dimensions", "expected a non-empty list");
+    }
+    arr->dimension_count = dims.size();
+    arr->dimensions = alloc_zeroed<ZarrDimensionProperties>(dims.size());
+    for (size_t i = 0; i < dims.size(); ++i) {
+        load_dimension(
+          dims[i], &arr->dimensions[i], ctx + ".dimensions[" + std::to_string(i) + "]");
+    }
+
+    if (j.contains("storage_dimension_order") &&
+        !j.at("storage_dimension_order").is_null()) {
+        const auto& order = j.at("storage_dimension_order");
+        if (!order.is_array() || order.size() != arr->dimension_count) {
+            fail(ctx + ".storage_dimension_order",
+                 "must have one entry per dimension");
+        }
+        auto* buf = alloc_zeroed<size_t>(order.size());
+        arr->storage_dimension_order = buf;
+        for (size_t i = 0; i < order.size(); ++i) {
+            buf[i] = static_cast<size_t>(
+              as_u64(order[i], ctx + ".storage_dimension_order"));
+        }
+    }
+}
+
+void
+load_acquisition(const json& j, ZarrHCSAcquisition* acq, const std::string& ctx)
+{
+    acq->id = as_u32(require(j, "id", ctx), ctx + ".id");
+    if (j.contains("name") && !j.at("name").is_null()) {
+        acq->name = dup_cstr(as_string(j.at("name"), ctx + ".name"));
+    }
+    if (j.contains("description") && !j.at("description").is_null()) {
+        acq->description = dup_cstr(as_string(j.at("description"), ctx + ".description"));
+    }
+    if (j.contains("start_time") && !j.at("start_time").is_null()) {
+        acq->start_time = as_u64(j.at("start_time"), ctx + ".start_time");
+        acq->has_start_time = true;
+    }
+    if (j.contains("end_time") && !j.at("end_time").is_null()) {
+        acq->end_time = as_u64(j.at("end_time"), ctx + ".end_time");
+        acq->has_end_time = true;
+    }
+}
+
+void
+load_fov(const json& j, ZarrHCSFieldOfView* fov, const std::string& ctx)
+{
+    fov->path = dup_cstr(as_string(require(j, "path", ctx), ctx + ".path"));
+    if (j.contains("acquisition_id") && !j.at("acquisition_id").is_null()) {
+        fov->acquisition_id = as_u32(j.at("acquisition_id"), ctx + ".acquisition_id");
+        fov->has_acquisition_id = true;
+    }
+    fov->array_settings = alloc_zeroed<ZarrArraySettings>(1);
+    load_array(require(j, "array", ctx), fov->array_settings, ctx + ".array", false);
+}
+
+void
+load_well(const json& j, ZarrHCSWell* well, const std::string& ctx)
+{
+    well->row_name = dup_cstr(as_string(require(j, "row_name", ctx), ctx + ".row_name"));
+    well->column_name =
+      dup_cstr(as_string(require(j, "column_name", ctx), ctx + ".column_name"));
+
+    const auto& images = require(j, "images", ctx);
+    if (!images.is_array()) {
+        fail(ctx + ".images", "expected a list");
+    }
+    well->image_count = images.size();
+    well->images = alloc_zeroed<ZarrHCSFieldOfView>(images.size());
+    for (size_t i = 0; i < images.size(); ++i) {
+        load_fov(images[i], &well->images[i], ctx + ".images[" + std::to_string(i) + "]");
+    }
+}
+
+std::vector<std::string>
+as_string_list(const json& j, const std::string& ctx)
+{
+    if (!j.is_array()) {
+        fail(ctx, "expected a list");
+    }
+    std::vector<std::string> out;
+    out.reserve(j.size());
+    for (const auto& e : j) {
+        out.push_back(as_string(e, ctx));
+    }
+    return out;
+}
+
+const char**
+dup_string_list(const std::vector<std::string>& src)
+{
+    auto* arr = alloc_zeroed<const char*>(src.size());
+    for (size_t i = 0; i < src.size(); ++i) {
+        arr[i] = dup_cstr(src[i]);
+    }
+    return arr;
+}
+
+void
+load_plate(const json& j, ZarrHCSPlate* plate, const std::string& ctx)
+{
+    plate->path = dup_cstr(as_string(require(j, "path", ctx), ctx + ".path"));
+    if (j.contains("name") && !j.at("name").is_null()) {
+        plate->name = dup_cstr(as_string(j.at("name"), ctx + ".name"));
+    }
+
+    const auto rows = as_string_list(require(j, "row_names", ctx), ctx + ".row_names");
+    plate->row_count = rows.size();
+    plate->row_names = dup_string_list(rows);
+
+    const auto cols =
+      as_string_list(require(j, "column_names", ctx), ctx + ".column_names");
+    plate->column_count = cols.size();
+    plate->column_names = dup_string_list(cols);
+
+    const auto& wells = require(j, "wells", ctx);
+    if (!wells.is_array()) {
+        fail(ctx + ".wells", "expected a list");
+    }
+    plate->well_count = wells.size();
+    plate->wells = alloc_zeroed<ZarrHCSWell>(wells.size());
+    for (size_t i = 0; i < wells.size(); ++i) {
+        load_well(wells[i], &plate->wells[i], ctx + ".wells[" + std::to_string(i) + "]");
+    }
+
+    if (j.contains("acquisitions") && !j.at("acquisitions").is_null()) {
+        const auto& acqs = j.at("acquisitions");
+        if (!acqs.is_array()) {
+            fail(ctx + ".acquisitions", "expected a list");
+        }
+        plate->acquisition_count = acqs.size();
+        plate->acquisitions = alloc_zeroed<ZarrHCSAcquisition>(acqs.size());
+        for (size_t i = 0; i < acqs.size(); ++i) {
+            load_acquisition(acqs[i],
+                             &plate->acquisitions[i],
+                             ctx + ".acquisitions[" + std::to_string(i) + "]");
+        }
+    }
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// settings -> JSON (dump)
+// ---------------------------------------------------------------------------
+namespace {
+json
+dump_dimension(const ZarrDimensionProperties& d)
+{
+    json j;
+    j["name"] = d.name ? d.name : "";
+    j["type"] = from_enum(kDimensionTypes, d.type, "dimension type");
+    j["array_size_px"] = d.array_size_px;
+    j["chunk_size_px"] = d.chunk_size_px;
+    j["shard_size_chunks"] = d.shard_size_chunks;
+    if (d.unit) {
+        j["unit"] = d.unit;
+    }
+    j["scale"] = d.scale;
+    return j;
+}
+
+json
+dump_array(const ZarrArraySettings& a, bool include_output_key)
+{
+    json j;
+    if (include_output_key && a.output_key) {
+        j["output_key"] = a.output_key;
+    }
+    j["data_type"] = from_enum(kDataTypes, a.data_type, "data type");
+    j["multiscale"] = a.multiscale;
+    if (a.multiscale) {
+        j["downsampling_method"] =
+          from_enum(kDownsamplingMethods, a.downsampling_method, "downsampling method");
+        j["max_levels"] = a.max_levels;
+    }
+    if (a.compression_settings) {
+        const auto& c = *a.compression_settings;
+        j["compression"] = {
+            { "compressor", from_enum(kCompressors, c.compressor, "compressor") },
+            { "codec", from_enum(kCodecs, c.codec, "codec") },
+            { "level", c.level },
+            { "shuffle", c.shuffle },
+        };
+    }
+    j["dimensions"] = json::array();
+    for (size_t i = 0; i < a.dimension_count; ++i) {
+        j["dimensions"].push_back(dump_dimension(a.dimensions[i]));
+    }
+    if (a.storage_dimension_order) {
+        auto order = json::array();
+        for (size_t i = 0; i < a.dimension_count; ++i) {
+            order.push_back(a.storage_dimension_order[i]);
+        }
+        j["storage_dimension_order"] = order;
+    }
+    return j;
+}
+
+json
+dump_plate(const ZarrHCSPlate& p)
+{
+    json j;
+    j["path"] = p.path ? p.path : "";
+    if (p.name) {
+        j["name"] = p.name;
+    }
+    j["row_names"] = json::array();
+    for (size_t i = 0; i < p.row_count; ++i) {
+        j["row_names"].push_back(p.row_names[i] ? p.row_names[i] : "");
+    }
+    j["column_names"] = json::array();
+    for (size_t i = 0; i < p.column_count; ++i) {
+        j["column_names"].push_back(p.column_names[i] ? p.column_names[i] : "");
+    }
+    if (p.acquisition_count) {
+        auto acqs = json::array();
+        for (size_t i = 0; i < p.acquisition_count; ++i) {
+            const auto& a = p.acquisitions[i];
+            json aj;
+            aj["id"] = a.id;
+            if (a.name) {
+                aj["name"] = a.name;
+            }
+            if (a.description) {
+                aj["description"] = a.description;
+            }
+            if (a.has_start_time) {
+                aj["start_time"] = a.start_time;
+            }
+            if (a.has_end_time) {
+                aj["end_time"] = a.end_time;
+            }
+            acqs.push_back(aj);
+        }
+        j["acquisitions"] = acqs;
+    }
+    j["wells"] = json::array();
+    for (size_t i = 0; i < p.well_count; ++i) {
+        const auto& w = p.wells[i];
+        json wj;
+        wj["row_name"] = w.row_name ? w.row_name : "";
+        wj["column_name"] = w.column_name ? w.column_name : "";
+        wj["images"] = json::array();
+        for (size_t k = 0; k < w.image_count; ++k) {
+            const auto& fov = w.images[k];
+            json fj;
+            fj["path"] = fov.path ? fov.path : "";
+            if (fov.has_acquisition_id) {
+                fj["acquisition_id"] = fov.acquisition_id;
+            }
+            if (fov.array_settings) {
+                fj["array"] = dump_array(*fov.array_settings, false);
+            }
+            wj["images"].push_back(fj);
+        }
+        j["wells"].push_back(wj);
+    }
+    return j;
+}
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+namespace zarr {
+json
+config_text_to_json(const std::string& text)
+{
+    return yaml_to_json(YAML::Load(text));
+}
+
+std::string
+json_to_yaml(const json& doc)
+{
+    YAML::Emitter emitter;
+    emitter << json_to_yaml_node(doc);
+    return emitter.c_str();
+}
+
+void
+json_to_settings(const json& doc, ZarrStreamSettings* out)
+{
+    // zero first so a throw anywhere leaves a struct that is safe to pass to
+    // destroy_loaded_settings (free(nullptr) is a no-op; zeroed counts skip)
+    std::memset(out, 0, sizeof(*out));
+
+    if (!doc.is_object()) {
+        fail("", "config root must be a mapping");
+    }
+    if (doc.contains("version")) {
+        const auto v = as_u64(doc.at("version"), "version");
+        if (v != kSchemaVersion) {
+            fail("version",
+                 "unsupported schema version " + std::to_string(v) + " (expected " +
+                   std::to_string(kSchemaVersion) + ")");
+        }
+    }
+
+    out->store_path = dup_cstr(as_string(require(doc, "store_path", ""), "store_path"));
+    out->overwrite = doc.contains("overwrite") ? as_bool(doc.at("overwrite"), "overwrite") : false;
+    out->max_threads =
+      doc.contains("max_threads")
+        ? static_cast<unsigned int>(as_u32(doc.at("max_threads"), "max_threads"))
+        : 0;
+
+    if (doc.contains("s3") && !doc.at("s3").is_null()) {
+        const auto& s = doc.at("s3");
+        auto* s3 = alloc_zeroed<ZarrS3Settings>(1);
+        out->s3_settings = s3;
+        s3->endpoint = dup_cstr(as_string(require(s, "endpoint", "s3"), "s3.endpoint"));
+        s3->bucket_name =
+          dup_cstr(as_string(require(s, "bucket_name", "s3"), "s3.bucket_name"));
+        if (s.contains("region") && !s.at("region").is_null()) {
+            s3->region = dup_cstr(as_string(s.at("region"), "s3.region"));
+        }
+    }
+
+    if (doc.contains("arrays") && !doc.at("arrays").is_null()) {
+        const auto& arrays = doc.at("arrays");
+        if (!arrays.is_array()) {
+            fail("arrays", "expected a list");
+        }
+        out->array_count = arrays.size();
+        out->arrays = alloc_zeroed<ZarrArraySettings>(arrays.size());
+        for (size_t i = 0; i < arrays.size(); ++i) {
+            load_array(
+              arrays[i], &out->arrays[i], "arrays[" + std::to_string(i) + "]", true);
+        }
+    }
+
+    if (doc.contains("plates") && !doc.at("plates").is_null()) {
+        const auto& plates = doc.at("plates");
+        if (!plates.is_array()) {
+            fail("plates", "expected a list");
+        }
+        auto* hcs = alloc_zeroed<ZarrHCSSettings>(1);
+        out->hcs_settings = hcs;
+        hcs->plate_count = plates.size();
+        hcs->plates = alloc_zeroed<ZarrHCSPlate>(plates.size());
+        for (size_t i = 0; i < plates.size(); ++i) {
+            load_plate(
+              plates[i], &hcs->plates[i], "plates[" + std::to_string(i) + "]");
+        }
+    }
+
+    if (!out->arrays && !out->hcs_settings) {
+        fail("", "config must define 'arrays' and/or 'plates'");
+    }
+}
+
+json
+settings_to_json(const ZarrStreamSettings* s)
+{
+    json doc;
+    doc["version"] = kSchemaVersion;
+    doc["store_path"] = s->store_path ? s->store_path : "";
+    doc["overwrite"] = s->overwrite;
+    doc["max_threads"] = s->max_threads;
+
+    if (s->s3_settings) {
+        const auto& s3 = *s->s3_settings;
+        doc["s3"] = {
+            { "endpoint", s3.endpoint ? s3.endpoint : "" },
+            { "bucket_name", s3.bucket_name ? s3.bucket_name : "" },
+        };
+        if (s3.region) {
+            doc["s3"]["region"] = s3.region;
+        }
+    }
+
+    if (s->arrays && s->array_count) {
+        doc["arrays"] = json::array();
+        for (size_t i = 0; i < s->array_count; ++i) {
+            doc["arrays"].push_back(dump_array(s->arrays[i], true));
+        }
+    }
+
+    if (s->hcs_settings && s->hcs_settings->plate_count) {
+        doc["plates"] = json::array();
+        for (size_t i = 0; i < s->hcs_settings->plate_count; ++i) {
+            doc["plates"].push_back(dump_plate(s->hcs_settings->plates[i]));
+        }
+    }
+
+    return doc;
+}
+
+namespace {
+void
+free_array_contents(ZarrArraySettings* a)
+{
+    if (!a) {
+        return;
+    }
+    free_cstr(a->output_key);
+    std::free(a->compression_settings);
+    std::free(const_cast<size_t*>(a->storage_dimension_order));
+    if (a->dimensions) {
+        for (size_t i = 0; i < a->dimension_count; ++i) {
+            free_cstr(a->dimensions[i].name);
+            free_cstr(a->dimensions[i].unit);
+        }
+        std::free(a->dimensions);
+    }
+}
+} // namespace
+
+void
+destroy_loaded_settings(ZarrStreamSettings* s)
+{
+    if (!s) {
+        return;
+    }
+
+    free_cstr(s->store_path);
+
+    if (s->s3_settings) {
+        free_cstr(s->s3_settings->endpoint);
+        free_cstr(s->s3_settings->bucket_name);
+        free_cstr(s->s3_settings->region);
+        std::free(s->s3_settings);
+    }
+
+    if (s->arrays) {
+        for (size_t i = 0; i < s->array_count; ++i) {
+            free_array_contents(&s->arrays[i]);
+        }
+        std::free(s->arrays);
+    }
+
+    if (s->hcs_settings) {
+        for (size_t p = 0; p < s->hcs_settings->plate_count; ++p) {
+            auto& plate = s->hcs_settings->plates[p];
+            free_cstr(plate.path);
+            free_cstr(plate.name);
+            for (size_t i = 0; i < plate.row_count; ++i) {
+                free_cstr(plate.row_names[i]);
+            }
+            std::free(const_cast<const char**>(plate.row_names));
+            for (size_t i = 0; i < plate.column_count; ++i) {
+                free_cstr(plate.column_names[i]);
+            }
+            std::free(const_cast<const char**>(plate.column_names));
+            for (size_t i = 0; i < plate.acquisition_count; ++i) {
+                free_cstr(plate.acquisitions[i].name);
+                free_cstr(plate.acquisitions[i].description);
+            }
+            std::free(plate.acquisitions);
+            for (size_t i = 0; i < plate.well_count; ++i) {
+                auto& well = plate.wells[i];
+                free_cstr(well.row_name);
+                free_cstr(well.column_name);
+                for (size_t k = 0; k < well.image_count; ++k) {
+                    free_cstr(well.images[k].path);
+                    free_array_contents(well.images[k].array_settings);
+                    std::free(well.images[k].array_settings);
+                }
+                std::free(well.images);
+            }
+            std::free(plate.wells);
+        }
+        std::free(s->hcs_settings->plates);
+        std::free(s->hcs_settings);
+    }
+
+    std::memset(s, 0, sizeof(*s));
+}
+} // namespace zarr
+
+// ---------------------------------------------------------------------------
+// C entrypoints
+// ---------------------------------------------------------------------------
+namespace {
+std::string
+read_file(const std::string& path)
+{
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        throw std::runtime_error("Failed to open config file: " + path);
+    }
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+ZarrStatusCode
+load_from(const std::string& text, ZarrStreamSettings* settings)
+{
+    try {
+        zarr::json_to_settings(zarr::config_text_to_json(text), settings);
+    } catch (const std::exception& exc) {
+        LOG_ERROR("Failed to load settings: ", exc.what());
+        zarr::destroy_loaded_settings(settings); // release any partial allocation
+        return ZarrStatusCode_InvalidSettings;
+    }
+    return ZarrStatusCode_Success;
+}
+} // namespace
+
+extern "C"
+{
+    ZarrStatusCode ZarrStreamSettings_load_from_file(
+      ZarrStreamSettings* settings,
+      const char* path)
+    {
+        EXPECT_VALID_ARGUMENT(settings, "Null pointer: settings");
+        EXPECT_VALID_ARGUMENT(path, "Null pointer: path");
+        try {
+            return load_from(read_file(path), settings);
+        } catch (const std::exception& exc) {
+            LOG_ERROR("Failed to read config file: ", exc.what());
+            return ZarrStatusCode_IOError;
+        }
+    }
+
+    ZarrStatusCode ZarrStreamSettings_load_from_string(
+      ZarrStreamSettings* settings,
+      const char* text)
+    {
+        EXPECT_VALID_ARGUMENT(settings, "Null pointer: settings");
+        EXPECT_VALID_ARGUMENT(text, "Null pointer: text");
+        return load_from(text, settings);
+    }
+
+    void ZarrStreamSettings_destroy_loaded(ZarrStreamSettings* settings)
+    {
+        if (settings) {
+            zarr::destroy_loaded_settings(settings);
+        }
+    }
+
+    ZarrStatusCode ZarrStreamSettings_dump_to_file(
+      const ZarrStreamSettings* settings,
+      const char* path)
+    {
+        EXPECT_VALID_ARGUMENT(settings, "Null pointer: settings");
+        EXPECT_VALID_ARGUMENT(path, "Null pointer: path");
+
+        std::string p(path);
+        const bool js = p.size() >= 5 && p.substr(p.size() - 5) == ".json";
+
+        try {
+            const auto doc = zarr::settings_to_json(settings);
+            const std::string out = js ? doc.dump(2) : zarr::json_to_yaml(doc);
+            std::ofstream f(p, std::ios::binary);
+            if (!f) {
+                LOG_ERROR("Failed to open output file: ", p);
+                return ZarrStatusCode_IOError;
+            }
+            f << out;
+        } catch (const std::exception& exc) {
+            LOG_ERROR("Failed to dump settings: ", exc.what());
+            return ZarrStatusCode_InternalError;
+        }
+        return ZarrStatusCode_Success;
+    }
+
+    ZarrStatusCode ZarrStreamSettings_dump_to_string(
+      const ZarrStreamSettings* settings,
+      char** text,
+      ZarrConfigFormat format)
+    {
+        EXPECT_VALID_ARGUMENT(settings, "Null pointer: settings");
+        EXPECT_VALID_ARGUMENT(text, "Null pointer: text");
+        EXPECT_VALID_ARGUMENT(format < ZarrConfigFormatCount,
+                              "Invalid config format: ",
+                              static_cast<int>(format));
+
+        try {
+            const auto doc = zarr::settings_to_json(settings);
+            const std::string out =
+              format == ZarrConfigFormat_Json ? doc.dump(2) : zarr::json_to_yaml(doc);
+
+            auto* buf = static_cast<char*>(std::malloc(out.size() + 1));
+            if (!buf) {
+                return ZarrStatusCode_OutOfMemory;
+            }
+            std::memcpy(buf, out.c_str(), out.size() + 1);
+            *text = buf;
+        } catch (const std::exception& exc) {
+            LOG_ERROR("Failed to dump settings: ", exc.what());
+            return ZarrStatusCode_InternalError;
+        }
+        return ZarrStatusCode_Success;
+    }
+}

--- a/src/streaming/settings.io.cpp
+++ b/src/streaming/settings.io.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -22,8 +23,11 @@ json
 scalar_to_json(const YAML::Node& node)
 {
     const auto& s = node.Scalar();
-    if (node.Tag() == "tag:yaml.org,2002:str") {
-        return s; // explicitly tagged string, e.g. a numeric well name
+    // yaml-cpp tags quoted scalars "!"; an explicit !!str tag becomes
+    // "tag:yaml.org,2002:str". Either means "treat as string verbatim",
+    // e.g. a numeric well name or an intentional empty string.
+    if (node.Tag() == "!" || node.Tag() == "tag:yaml.org,2002:str") {
+        return s;
     }
 
     // Strict JSON-style booleans only. yaml-cpp follows YAML 1.1, where y/yes/
@@ -262,8 +266,29 @@ as_string(const json& j, const std::string& ctx)
     fail(ctx, "expected a string");
 }
 
+template<typename T>
+T as_uint(const json& j, const std::string& ctx);
+
+template<>
+uint64_t as_uint<uint64_t>(const json& j, const std::string& ctx);
+
+template<typename T>
+T
+as_uint(const json& j, const std::string& ctx)
+{
+    static_assert(std::is_unsigned_v<T>);
+    const auto v = as_uint<uint64_t>(j, ctx);
+    if (v > std::numeric_limits<T>::max()) {
+        fail(ctx,
+             "value out of range (max " +
+               std::to_string(std::numeric_limits<T>::max()) + ")");
+    }
+    return static_cast<T>(v);
+}
+
+template<>
 uint64_t
-as_u64(const json& j, const std::string& ctx)
+as_uint(const json& j, const std::string& ctx)
 {
     if (j.is_number_unsigned()) {
         return j.get<uint64_t>();
@@ -283,12 +308,6 @@ as_u64(const json& j, const std::string& ctx)
         }
     }
     fail(ctx, "expected an integer");
-}
-
-uint32_t
-as_u32(const json& j, const std::string& ctx)
-{
-    return static_cast<uint32_t>(as_u64(j, ctx));
 }
 
 bool
@@ -366,11 +385,12 @@ load_dimension(const json& j,
               as_string(require(j, "type", ctx), ctx + ".type"),
               "dimension type"));
     dim->array_size_px =
-      as_u32(require(j, "array_size_px", ctx), ctx + ".array_size_px");
+      as_uint<uint32_t>(require(j, "array_size_px", ctx), ctx + ".array_size_px");
     dim->chunk_size_px =
-      as_u32(require(j, "chunk_size_px", ctx), ctx + ".chunk_size_px");
+      as_uint<uint32_t>(require(j, "chunk_size_px", ctx), ctx + ".chunk_size_px");
     dim->shard_size_chunks =
-      as_u32(require(j, "shard_size_chunks", ctx), ctx + ".shard_size_chunks");
+      as_uint<uint32_t>(require(j, "shard_size_chunks", ctx),
+                        ctx + ".shard_size_chunks");
 
     if (j.contains("unit") && !j.at("unit").is_null()) {
         dim->unit = dup_cstr(as_string(j.at("unit"), ctx + ".unit"));
@@ -407,7 +427,8 @@ load_array(const json& j,
                   "downsampling method")
         : ZarrDownsamplingMethod_Decimate);
     arr->max_levels = j.contains("max_levels")
-                        ? as_u32(j.at("max_levels"), ctx + ".max_levels")
+                        ? as_uint<uint32_t>(j.at("max_levels"),
+                                            ctx + ".max_levels")
                         : 0;
 
     if (j.contains("compression") && !j.at("compression").is_null()) {
@@ -424,13 +445,11 @@ load_array(const json& j,
                   as_string(require(c, "codec", cctx), cctx + ".codec"),
                   "codec"));
         cs->level =
-          c.contains("level")
-            ? static_cast<uint8_t>(as_u32(c.at("level"), cctx + ".level"))
-            : 0;
-        cs->shuffle =
-          c.contains("shuffle")
-            ? static_cast<uint8_t>(as_u32(c.at("shuffle"), cctx + ".shuffle"))
-            : 0;
+          c.contains("level") ? as_uint<uint8_t>(c.at("level"), cctx + ".level")
+                              : 0;
+        cs->shuffle = c.contains("shuffle")
+                        ? as_uint<uint8_t>(c.at("shuffle"), cctx + ".shuffle")
+                        : 0;
     }
 
     const auto& dims = require(j, "dimensions", ctx);
@@ -456,7 +475,7 @@ load_array(const json& j,
         arr->storage_dimension_order = buf;
         for (size_t i = 0; i < order.size(); ++i) {
             buf[i] = static_cast<size_t>(
-              as_u64(order[i], ctx + ".storage_dimension_order"));
+              as_uint<uint64_t>(order[i], ctx + ".storage_dimension_order"));
         }
     }
 }
@@ -464,7 +483,7 @@ load_array(const json& j,
 void
 load_acquisition(const json& j, ZarrHCSAcquisition* acq, const std::string& ctx)
 {
-    acq->id = as_u32(require(j, "id", ctx), ctx + ".id");
+    acq->id = as_uint<uint32_t>(require(j, "id", ctx), ctx + ".id");
     if (j.contains("name") && !j.at("name").is_null()) {
         acq->name = dup_cstr(as_string(j.at("name"), ctx + ".name"));
     }
@@ -473,11 +492,11 @@ load_acquisition(const json& j, ZarrHCSAcquisition* acq, const std::string& ctx)
           dup_cstr(as_string(j.at("description"), ctx + ".description"));
     }
     if (j.contains("start_time") && !j.at("start_time").is_null()) {
-        acq->start_time = as_u64(j.at("start_time"), ctx + ".start_time");
+        acq->start_time = as_uint<uint64_t>(j.at("start_time"), ctx + ".start_time");
         acq->has_start_time = true;
     }
     if (j.contains("end_time") && !j.at("end_time").is_null()) {
-        acq->end_time = as_u64(j.at("end_time"), ctx + ".end_time");
+        acq->end_time = as_uint<uint64_t>(j.at("end_time"), ctx + ".end_time");
         acq->has_end_time = true;
     }
 }
@@ -488,7 +507,7 @@ load_fov(const json& j, ZarrHCSFieldOfView* fov, const std::string& ctx)
     fov->path = dup_cstr(as_string(require(j, "path", ctx), ctx + ".path"));
     if (j.contains("acquisition_id") && !j.at("acquisition_id").is_null()) {
         fov->acquisition_id =
-          as_u32(j.at("acquisition_id"), ctx + ".acquisition_id");
+          as_uint<uint32_t>(j.at("acquisition_id"), ctx + ".acquisition_id");
         fov->has_acquisition_id = true;
     }
     fov->array_settings = alloc_zeroed<ZarrArraySettings>(1);
@@ -536,7 +555,15 @@ dup_string_list(const std::vector<std::string>& src)
 {
     auto* arr = alloc_zeroed<const char*>(src.size());
     for (size_t i = 0; i < src.size(); ++i) {
-        arr[i] = dup_cstr(src[i]);
+        try {
+            arr[i] = dup_cstr(src[i]);
+        } catch (...) {
+            for (size_t k = 0; k < i; ++k) {
+                free_cstr(arr[k]);
+            }
+            std::free(arr);
+            throw;
+        }
     }
     return arr;
 }
@@ -551,13 +578,13 @@ load_plate(const json& j, ZarrHCSPlate* plate, const std::string& ctx)
 
     const auto rows =
       as_string_list(require(j, "row_names", ctx), ctx + ".row_names");
-    plate->row_count = rows.size();
     plate->row_names = dup_string_list(rows);
+    plate->row_count = rows.size();
 
     const auto cols =
       as_string_list(require(j, "column_names", ctx), ctx + ".column_names");
-    plate->column_count = cols.size();
     plate->column_names = dup_string_list(cols);
+    plate->column_count = cols.size();
 
     const auto& wells = require(j, "wells", ctx);
     if (!wells.is_array()) {
@@ -737,7 +764,7 @@ json_to_settings(const json& doc, ZarrStreamSettings* out)
         fail("", "config root must be a mapping");
     }
     if (doc.contains("version")) {
-        const auto v = as_u64(doc.at("version"), "version");
+        const auto v = as_uint<uint64_t>(doc.at("version"), "version");
         if (v != kSchemaVersion) {
             fail("version",
                  "unsupported schema version " + std::to_string(v) +
@@ -752,7 +779,7 @@ json_to_settings(const json& doc, ZarrStreamSettings* out)
                        : false;
     out->max_threads = doc.contains("max_threads")
                          ? static_cast<unsigned int>(
-                             as_u32(doc.at("max_threads"), "max_threads"))
+                             as_uint<uint32_t>(doc.at("max_threads"), "max_threads"))
                          : 0;
 
     if (doc.contains("s3") && !doc.at("s3").is_null()) {
@@ -888,14 +915,18 @@ destroy_loaded_settings(ZarrStreamSettings* s)
             auto& plate = s->hcs_settings->plates[p];
             free_cstr(plate.path);
             free_cstr(plate.name);
-            for (size_t i = 0; i < plate.row_count; ++i) {
-                free_cstr(plate.row_names[i]);
+            if (plate.row_names) {
+                for (size_t i = 0; i < plate.row_count; ++i) {
+                    free_cstr(plate.row_names[i]);
+                }
+                std::free(const_cast<const char**>(plate.row_names));
             }
-            std::free(const_cast<const char**>(plate.row_names));
-            for (size_t i = 0; i < plate.column_count; ++i) {
-                free_cstr(plate.column_names[i]);
+            if (plate.column_names) {
+                for (size_t i = 0; i < plate.column_count; ++i) {
+                    free_cstr(plate.column_names[i]);
+                }
+                std::free(const_cast<const char**>(plate.column_names));
             }
-            std::free(const_cast<const char**>(plate.column_names));
             for (size_t i = 0; i < plate.acquisition_count; ++i) {
                 free_cstr(plate.acquisitions[i].name);
                 free_cstr(plate.acquisitions[i].description);

--- a/src/streaming/settings.io.hh
+++ b/src/streaming/settings.io.hh
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "acquire.zarr.h" // ZarrStreamSettings
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+
+// Load and dump ZarrStreamSettings from YAML/JSON config files. JSON is a
+// subset of YAML, so a single parse path handles both.
+namespace zarr {
+// Parse a YAML (or JSON) document into JSON. Throws on malformed input.
+nlohmann::json
+config_text_to_json(const std::string& text);
+
+// Emit a JSON document as YAML text.
+std::string
+json_to_yaml(const nlohmann::json& doc);
+
+// Build owning stream settings from a config document. Allocates all arrays,
+// dimensions, plates, and strings; free with destroy_loaded_settings. Throws
+// std::exception with a descriptive message on malformed input.
+void
+json_to_settings(const nlohmann::json& doc, ZarrStreamSettings* out);
+
+// Serialize stream settings into a config document.
+nlohmann::json
+settings_to_json(const ZarrStreamSettings* settings);
+
+// Free everything json_to_settings allocated.
+void
+destroy_loaded_settings(ZarrStreamSettings* settings);
+} // namespace zarr

--- a/src/streaming/settings.io.hh
+++ b/src/streaming/settings.io.hh
@@ -6,28 +6,51 @@
 
 #include <string>
 
-// Load and dump ZarrStreamSettings from YAML/JSON config files. JSON is a
-// subset of YAML, so a single parse path handles both.
+/**
+ * @brief Load and dump ZarrStreamSettings from YAML/JSON config files. JSON is
+ * a subset of YAML, so a single parse path handles both.
+ */
 namespace zarr {
-// Parse a YAML (or JSON) document into JSON. Throws on malformed input.
+/**
+ * @brief Parse a YAML (or JSON) document into JSON.
+ * @param text The config document.
+ * @return The parsed document as JSON.
+ * @throws std::exception on malformed input.
+ */
 nlohmann::json
 config_text_to_json(const std::string& text);
 
-// Emit a JSON document as YAML text.
+/**
+ * @brief Emit a JSON document as YAML text.
+ * @param doc The document to serialize.
+ * @return The document rendered as YAML.
+ */
 std::string
 json_to_yaml(const nlohmann::json& doc);
 
-// Build owning stream settings from a config document. Allocates all arrays,
-// dimensions, plates, and strings; free with destroy_loaded_settings. Throws
-// std::exception with a descriptive message on malformed input.
+/**
+ * @brief Build owning stream settings from a config document.
+ * @details Allocates all arrays, dimensions, plates, and strings; free with
+ * destroy_loaded_settings.
+ * @param doc The config document.
+ * @param[out] out The stream settings struct to populate.
+ * @throws std::exception with a descriptive message on malformed input.
+ */
 void
 json_to_settings(const nlohmann::json& doc, ZarrStreamSettings* out);
 
-// Serialize stream settings into a config document.
+/**
+ * @brief Serialize stream settings into a config document.
+ * @param settings The stream settings to serialize.
+ * @return The settings as a JSON document.
+ */
 nlohmann::json
 settings_to_json(const ZarrStreamSettings* settings);
 
-// Free everything json_to_settings allocated.
+/**
+ * @brief Free everything json_to_settings allocated.
+ * @param[in, out] settings The loader-populated stream settings struct.
+ */
 void
 destroy_loaded_settings(ZarrStreamSettings* settings);
 } // namespace zarr

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
         stream-mixed-flat-and-hcs-acquisition
         stream-with-ragged-final-shard
         stream-append-nullptr
+        stream-from-config-file
 )
 
 foreach (name ${tests})

--- a/tests/integration/stream-from-config-file.cpp
+++ b/tests/integration/stream-from-config-file.cpp
@@ -14,7 +14,7 @@ namespace fs = std::filesystem;
 namespace {
 const fs::path store = "config-test.zarr";
 
-const char* kYaml = R"(version: 1
+auto config_yaml = R"(version: 1
 store_path: config-test.zarr
 overwrite: true
 max_threads: 4
@@ -32,7 +32,7 @@ arrays:
       - {name: x, type: space, array_size_px: 64, chunk_size_px: 16, shard_size_chunks: 1, unit: micrometer, scale: 0.5}
 )";
 
-const char* kJson = R"({
+auto config_json = R"({
   "version": 1,
   "store_path": "config-test.zarr",
   "overwrite": true,
@@ -68,7 +68,8 @@ assert_expected(const ZarrStreamSettings& s)
 
     CHECK(a.compression_settings != nullptr);
     EXPECT_EQ(int, a.compression_settings->compressor, ZarrCompressor_Blosc1);
-    EXPECT_EQ(int, a.compression_settings->codec, ZarrCompressionCodec_BloscZstd);
+    EXPECT_EQ(
+      int, a.compression_settings->codec, ZarrCompressionCodec_BloscZstd);
     EXPECT_EQ(int, a.compression_settings->level, 1);
     EXPECT_EQ(int, a.compression_settings->shuffle, 1);
 
@@ -95,8 +96,11 @@ run_stream(ZarrStreamSettings* settings)
     std::vector<uint16_t> frame(48 * 64, 7);
     size_t bytes_out = 0;
     for (int i = 0; i < 10; ++i) { // one full z-stack at t=0
-        CHECK_OK(ZarrStream_append(
-          stream, frame.data(), frame.size() * sizeof(uint16_t), &bytes_out, nullptr));
+        CHECK_OK(ZarrStream_append(stream,
+                                   frame.data(),
+                                   frame.size() * sizeof(uint16_t),
+                                   &bytes_out,
+                                   nullptr));
     }
 
     CHECK_OK(ZarrStream_close(stream));
@@ -114,9 +118,9 @@ main()
     try {
         // both formats produce identical settings
         ZarrStreamSettings from_yaml{}, from_json{};
-        CHECK_OK(ZarrStreamSettings_load_from_string(&from_yaml, kYaml));
+        CHECK_OK(ZarrStreamSettings_load_from_string(&from_yaml, config_yaml));
         assert_expected(from_yaml);
-        CHECK_OK(ZarrStreamSettings_load_from_string(&from_json, kJson));
+        CHECK_OK(ZarrStreamSettings_load_from_string(&from_json, config_json));
         assert_expected(from_json);
 
         // round-trip through dump (YAML and JSON) reloads identically
@@ -143,12 +147,11 @@ main()
         EXPECT(ZarrStreamSettings_load_from_string(
                  &bad, "version: 1\nstore_path: x\n") != ZarrStatusCode_Success,
                "Expected failure: no arrays or plates");
-        EXPECT(
-          ZarrStreamSettings_load_from_string(
-            &bad,
-            "store_path: x\narrays:\n  - data_type: float128\n    dimensions: []\n") !=
-            ZarrStatusCode_Success,
-          "Expected failure: bad data_type");
+        EXPECT(ZarrStreamSettings_load_from_string(
+                 &bad,
+                 "store_path: x\narrays:\n  - data_type: float128\n    "
+                 "dimensions: []\n") != ZarrStatusCode_Success,
+               "Expected failure: bad data_type");
 
         retval = 0;
     } catch (const std::exception& e) {

--- a/tests/integration/stream-from-config-file.cpp
+++ b/tests/integration/stream-from-config-file.cpp
@@ -1,0 +1,162 @@
+// Load stream settings from YAML and JSON config files, round-trip via dump,
+// and confirm the loaded settings drive a working stream.
+// @see config-file support
+#include "acquire.zarr.h"
+#include "test.macros.hh"
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+const fs::path store = "config-test.zarr";
+
+const char* kYaml = R"(version: 1
+store_path: config-test.zarr
+overwrite: true
+max_threads: 4
+arrays:
+  - data_type: uint16
+    compression:
+      compressor: blosc1
+      codec: blosc-zstd
+      level: 1
+      shuffle: 1
+    dimensions:
+      - {name: t, type: time,  array_size_px: 0,  chunk_size_px: 5,  shard_size_chunks: 1}
+      - {name: z, type: space, array_size_px: 10, chunk_size_px: 5,  shard_size_chunks: 1}
+      - {name: y, type: space, array_size_px: 48, chunk_size_px: 16, shard_size_chunks: 1, unit: micrometer, scale: 0.5}
+      - {name: x, type: space, array_size_px: 64, chunk_size_px: 16, shard_size_chunks: 1, unit: micrometer, scale: 0.5}
+)";
+
+const char* kJson = R"({
+  "version": 1,
+  "store_path": "config-test.zarr",
+  "overwrite": true,
+  "max_threads": 4,
+  "arrays": [
+    {
+      "data_type": "uint16",
+      "compression": {"compressor": "blosc1", "codec": "blosc-zstd", "level": 1, "shuffle": 1},
+      "dimensions": [
+        {"name": "t", "type": "time",  "array_size_px": 0,  "chunk_size_px": 5,  "shard_size_chunks": 1},
+        {"name": "z", "type": "space", "array_size_px": 10, "chunk_size_px": 5,  "shard_size_chunks": 1},
+        {"name": "y", "type": "space", "array_size_px": 48, "chunk_size_px": 16, "shard_size_chunks": 1, "unit": "micrometer", "scale": 0.5},
+        {"name": "x", "type": "space", "array_size_px": 64, "chunk_size_px": 16, "shard_size_chunks": 1, "unit": "micrometer", "scale": 0.5}
+      ]
+    }
+  ]
+})";
+
+void
+assert_expected(const ZarrStreamSettings& s)
+{
+    EXPECT_STR_EQ(s.store_path, "config-test.zarr");
+    CHECK(s.overwrite);
+    EXPECT_EQ(unsigned, s.max_threads, 4u);
+    EXPECT_EQ(size_t, s.array_count, 1u);
+    CHECK(s.s3_settings == nullptr);
+    CHECK(s.hcs_settings == nullptr);
+
+    const auto& a = s.arrays[0];
+    CHECK(a.output_key == nullptr);
+    EXPECT_EQ(int, a.data_type, ZarrDataType_uint16);
+    CHECK(!a.multiscale);
+
+    CHECK(a.compression_settings != nullptr);
+    EXPECT_EQ(int, a.compression_settings->compressor, ZarrCompressor_Blosc1);
+    EXPECT_EQ(int, a.compression_settings->codec, ZarrCompressionCodec_BloscZstd);
+    EXPECT_EQ(int, a.compression_settings->level, 1);
+    EXPECT_EQ(int, a.compression_settings->shuffle, 1);
+
+    EXPECT_EQ(size_t, a.dimension_count, 4u);
+    EXPECT_STR_EQ(a.dimensions[0].name, "t");
+    EXPECT_EQ(int, a.dimensions[0].type, ZarrDimensionType_Time);
+    EXPECT_EQ(uint32_t, a.dimensions[0].chunk_size_px, 5u);
+    EXPECT_STR_EQ(a.dimensions[2].name, "y");
+    EXPECT_STR_EQ(a.dimensions[2].unit, "micrometer");
+    CHECK(a.dimensions[2].scale == 0.5);
+    CHECK(a.storage_dimension_order == nullptr);
+}
+
+void
+run_stream(ZarrStreamSettings* settings)
+{
+    if (fs::exists(store)) {
+        fs::remove_all(store);
+    }
+
+    ZarrStream* stream = ZarrStream_create(settings);
+    CHECK(stream != nullptr);
+
+    std::vector<uint16_t> frame(48 * 64, 7);
+    size_t bytes_out = 0;
+    for (int i = 0; i < 10; ++i) { // one full z-stack at t=0
+        CHECK_OK(ZarrStream_append(
+          stream, frame.data(), frame.size() * sizeof(uint16_t), &bytes_out, nullptr));
+    }
+
+    CHECK_OK(ZarrStream_close(stream));
+    CHECK(fs::exists(store));
+    CHECK(fs::exists(store / "zarr.json"));
+    fs::remove_all(store);
+}
+} // namespace
+
+int
+main()
+{
+    int retval = 1;
+
+    try {
+        // both formats produce identical settings
+        ZarrStreamSettings from_yaml{}, from_json{};
+        CHECK_OK(ZarrStreamSettings_load_from_string(&from_yaml, kYaml));
+        assert_expected(from_yaml);
+        CHECK_OK(ZarrStreamSettings_load_from_string(&from_json, kJson));
+        assert_expected(from_json);
+
+        // round-trip through dump (YAML and JSON) reloads identically
+        for (auto fmt : { ZarrConfigFormat_Yaml, ZarrConfigFormat_Json }) {
+            char* text = nullptr;
+            CHECK_OK(ZarrStreamSettings_dump_to_string(&from_yaml, &text, fmt));
+            CHECK(text != nullptr);
+
+            ZarrStreamSettings reloaded{};
+            CHECK_OK(ZarrStreamSettings_load_from_string(&reloaded, text));
+            assert_expected(reloaded);
+            ZarrStreamSettings_destroy_loaded(&reloaded);
+            free(text);
+        }
+
+        // loaded settings drive a working stream
+        run_stream(&from_yaml);
+
+        ZarrStreamSettings_destroy_loaded(&from_yaml);
+        ZarrStreamSettings_destroy_loaded(&from_json);
+
+        // malformed configs are rejected
+        ZarrStreamSettings bad{};
+        EXPECT(ZarrStreamSettings_load_from_string(
+                 &bad, "version: 1\nstore_path: x\n") != ZarrStatusCode_Success,
+               "Expected failure: no arrays or plates");
+        EXPECT(
+          ZarrStreamSettings_load_from_string(
+            &bad,
+            "store_path: x\narrays:\n  - data_type: float128\n    dimensions: []\n") !=
+            ZarrStatusCode_Success,
+          "Expected failure: bad data_type");
+
+        retval = 0;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Test failed: ", e.what());
+    }
+
+    if (fs::exists(store)) {
+        fs::remove_all(store);
+    }
+    return retval;
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -19,6 +19,10 @@
     {
       "name": "zstd",
       "version>=": "1.5.5"
+    },
+    {
+      "name": "yaml-cpp",
+      "version>=": "0.8.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds config-file support so the declarative parts of `ZarrStreamSettings` can be expressed in a **YAML or JSON** file instead of being built entirely through the C/Python API. JSON is a subset of YAML, so a single **yaml-cpp** parse path handles both, bridged through `nlohmann::json`.

Covers: store path, `overwrite`, `max_threads`, S3 endpoint/bucket/region, arrays (data type, compression, multiscale, downsampling, `max_levels`, storage dimension order), dimensions (name/type/sizes/unit/scale), and full HCS plate/well/FOV/acquisition trees.

## API

**C** (`acquire.zarr.h`):
- `ZarrStreamSettings_load_from_file` / `_load_from_string` — owning; free with `ZarrStreamSettings_destroy_loaded`
- `ZarrStreamSettings_dump_to_file` (format by extension) / `_dump_to_string`
- `ZarrConfigFormat { Yaml, Json }`

**Python**: `StreamSettings.from_file` / `from_string` / `from_dict` and `to_file` / `to_yaml` / `to_json` / `to_dict` — routed through the C++ core (and, for dict, Python's `json`) so there's a single parse/validate/emit path with no duplicated schema logic.

## Design notes

- **Secrets are never read from config** — S3 credentials still come from the environment/IAM; the file only carries endpoint/bucket/region.
- A top-level **`version`** field gates future schema changes.
- Booleans are strict JSON-style `true`/`false` (yaml-cpp's YAML 1.1 would otherwise read a dimension named `y` as a boolean).
- On **YAML dump**, strings that would otherwise reload as a bool/int/float/null (e.g. a numeric well name like `"5"`) are emitted double-quoted, so dump→load round-trips losslessly. JSON dump is lossless by construction.
- Ownership: the loader owns the whole tree and frees it via `destroy_loaded`; the Python binding deep-copies into its own objects.
- Adds **yaml-cpp** (`>= 0.8.0`) as a vcpkg dependency.

## Tests / examples

- C++ integration `stream-from-config-file`: identical YAML vs JSON load, dump→reload round-trip (both formats), loaded settings drive a real stream, malformed configs rejected.
- Python `test_settings.py`: parametrized YAML/JSON load, round-trip through `to_yaml`/`to_json`/`to_file` and `to_dict`/`from_dict`, ambiguous-string (numeric well name) YAML round-trip, malformed→`ValueError`.
- Examples under `examples/config/` (`flat.yaml`, `flat.json`, `hcs.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
