### PR TITLE
Close sealed chunk/shard file handles so reclaimed space is freed

### DIFF
--- a/src/streaming/file.handle.cpp
+++ b/src/streaming/file.handle.cpp
@@ -109,6 +109,26 @@ zarr::FileHandlePool::return_handle(const std::string& filename)
 }
 
 void
+zarr::FileHandlePool::close(const std::string& filename)
+{
+    std::unique_lock lock(mutex_);
+
+    const auto it = cache_.find(filename);
+    if (it == cache_.end() || it->second.refcount > 0) {
+        // Not cached, or still borrowed by an in-flight write: leave it. A
+        // borrowed handle is reclaimed by the next return_handle eviction once
+        // the borrow ends.
+        return;
+    }
+
+    lru_order_.erase(it->second.lru_it);
+    cache_.erase(it); // destroys FileHandle -> close
+    cache_space_available_ = cache_.size() < max_active_handles_;
+
+    cv_.notify_all();
+}
+
+void
 zarr::FileHandlePool::evict_lru_()
 {
     // iterate from back (least recent) looking for idle handle

--- a/src/streaming/file.handle.hh
+++ b/src/streaming/file.handle.hh
@@ -68,11 +68,15 @@ class FileHandlePool
     BorrowedHandle get_handle(const std::string& filename);
     void return_handle(const std::string& filename);
 
-    // Close and evict the pooled handle for @p filename, if it is cached and
-    // not currently borrowed (refcount == 0). Called when a sink is finalized:
-    // the file is sealed and will never be written again, so closing its fd
-    // lets the OS release it and a later unlink reclaim the disk blocks. A
-    // no-op if the handle is absent or still in use (issue #226).
+    /**
+     * @brief Close and evict the pooled handle for @p filename.
+     * @details Only acts when the handle is cached and not currently borrowed
+     * (refcount == 0). Called when a sink is finalized: the file is sealed and
+     * will never be written again, so closing its fd lets the OS release it and
+     * a later unlink can reclaim the disk blocks. A no-op if the handle is
+     * absent or still in use (issue #226).
+     * @param filename Path of the file whose handle should be closed.
+     */
     void close(const std::string& filename);
 
   private:

--- a/src/streaming/file.handle.hh
+++ b/src/streaming/file.handle.hh
@@ -68,6 +68,13 @@ class FileHandlePool
     BorrowedHandle get_handle(const std::string& filename);
     void return_handle(const std::string& filename);
 
+    // Close and evict the pooled handle for @p filename, if it is cached and
+    // not currently borrowed (refcount == 0). Called when a sink is finalized:
+    // the file is sealed and will never be written again, so closing its fd
+    // lets the OS release it and a later unlink reclaim the disk blocks. A
+    // no-op if the handle is absent or still in use (issue #226).
+    void close(const std::string& filename);
+
   private:
     struct CacheEntry
     {

--- a/src/streaming/file.sink.cpp
+++ b/src/streaming/file.sink.cpp
@@ -17,6 +17,18 @@ zarr::FileSink::FileSink(std::string_view filename,
     EXPECT(file_handle_pool_ != nullptr, "File handle pool not provided.");
 }
 
+zarr::FileSink::~FileSink()
+{
+    // The sink is being finalized/destroyed, so this file is sealed: the
+    // writer will never touch it again. Proactively close the pooled handle so
+    // the OS frees the fd and a later unlink can reclaim the disk blocks. Left
+    // open, the pool keeps the handle for the store's lifetime, and deleting a
+    // sealed chunk frees no space on the local filesystem (issue #226).
+    if (file_handle_pool_ != nullptr) {
+        file_handle_pool_->close(filename_);
+    }
+}
+
 bool
 zarr::FileSink::write(size_t offset, ConstByteSpan data)
 {

--- a/src/streaming/file.sink.hh
+++ b/src/streaming/file.sink.hh
@@ -13,7 +13,7 @@ class FileSink : public Sink
   public:
     FileSink(std::string_view filename,
              std::shared_ptr<FileHandlePool> file_handle_pool);
-    ~FileSink() override = default;
+    ~FileSink() override;
 
     bool write(size_t offset, ConstByteSpan data) override;
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
         s3-connection-put-object
         s3-connection-upload-multipart-object
         file-sink-write
+        file-sink-close-on-destroy
         shard-finalize
         s3-sink-write
         s3-sink-write-multipart

--- a/tests/unit-tests/file-sink-close-on-destroy.cpp
+++ b/tests/unit-tests/file-sink-close-on-destroy.cpp
@@ -1,0 +1,86 @@
+// Verify that destroying a FileSink closes the pooled file handle so the OS
+// can reclaim disk blocks when the file is subsequently deleted (issue #226).
+//
+// Observable:
+//   Windows -- CreateFileA uses FILE_SHARE_READ|FILE_SHARE_WRITE but not
+//              FILE_SHARE_DELETE, so DeleteFile fails (ERROR_SHARING_VIOLATION)
+//              while the HANDLE is still cached in the pool.  With the fix the
+//              destructor calls pool->close(), evicting the handle before the
+//              remove.
+//   Linux   -- unlink always succeeds, but open fds keep the inode alive and
+//              disk blocks are not freed until all fds are closed.  We count
+//              /proc/self/fd entries before and after to confirm the fd was
+//              actually released.
+
+#include "file.sink.hh"
+#include "unit.test.macros.hh"
+
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+#if defined(__linux__)
+static int
+count_open_fds()
+{
+    int n = 0;
+    for ([[maybe_unused]] auto& _ : fs::directory_iterator("/proc/self/fd")) {
+        ++n;
+    }
+    return n;
+}
+#endif
+
+int
+main()
+{
+    int retval = 0;
+    const fs::path tmp_path = fs::temp_directory_path() / TEST;
+
+    try {
+        auto pool = std::make_shared<zarr::FileHandlePool>();
+
+#if defined(__linux__)
+        const int fds_before = count_open_fds();
+#endif
+
+        {
+            char data[] = "close-on-destroy";
+            std::span<uint8_t> span = { reinterpret_cast<uint8_t*>(data),
+                                        sizeof(data) - 1 };
+            auto sink = std::make_unique<zarr::FileSink>(
+              tmp_path.string(), pool);
+            CHECK(sink->write(0, span));
+            CHECK(zarr::finalize_sink(std::move(sink)));
+            // ~FileSink() called here -- pool->close(filename_) must evict the
+            // cached handle before we attempt the remove below.
+        }
+
+#if defined(__linux__)
+        const int fds_after = count_open_fds();
+        EXPECT(fds_after <= fds_before,
+               "Open fd count did not decrease after FileSink destruction "
+               "(before=",
+               fds_before,
+               " after=",
+               fds_after,
+               "): handle may still be cached in the pool");
+#endif
+
+        // On Windows this fails with ERROR_SHARING_VIOLATION if the HANDLE is
+        // still open; on all platforms it must succeed with the fix in place.
+        std::error_code ec;
+        EXPECT(fs::remove(tmp_path, ec),
+               "fs::remove failed after FileSink destruction "
+               "(handle may still be open): ",
+               ec.message());
+
+    } catch (const std::exception& e) {
+        LOG_ERROR("Caught exception: ", e.what());
+        retval = 1;
+    }
+
+    std::error_code ec;
+    fs::remove(tmp_path, ec);
+    return retval;
+}


### PR DESCRIPTION
## Problem
FileHandlePool caps open handles at get_max_active_handles(), which returns
the full RLIMIT_NOFILE soft limit. Where that limit is large (e.g. 1048576),
the LRU cap is effectively never reached, so a handle opened for a
chunk/shard file stays cached in the pool for the entire lifetime of the
stream.

For a long-running stream that means every sealed chunk/shard file keeps an
open fd. If an external process deletes finished files after transferring
them elsewhere, the unlink removes the directory entry but the blocks are
not freed while the writer holds the fd (deleted-but-open inode on
Linux/XFS). Local storage fills even though the visible tree stays bounded.
Observed on a multi-day filesystem stream: thousands of deleted-but-open
chunk fds, free space falling steadily while du stayed flat.

## Fix
Close a file's pooled handle the moment its sink is finalized. A finalized
FileSink never writes its file again, so its destructor evicts the handle
via a new FileHandlePool::close(filename) (a no-op if absent or still
borrowed). The fd is released at the natural end of the file's life, so a
later unlink frees the blocks immediately. No open/close churn is added
during writing: handles are still cached and reused across a sink's writes;
only the finished file is closed at finalize.

## Validation
- Sharded [t, g, y, x] store: open fds stay bounded to the in-progress
  working set (single digits) instead of growing linearly with sealed shards.
- Unlinking sealed shards mid-stream frees disk (deleted-but-open gap gone).
- 0 open fds after close() (unchanged).
- Python suite (test_stream.py, test_dimension_transposition.py): 62 passed.

## Changes
- FileHandlePool::close(filename): close + evict an idle pooled handle.
- ~FileSink() calls it on finalize/destroy.
