### PR TITLE
Fix file reopen failure crashing the writer during append (regression from #237)

### DIFF
--- a/src/streaming/file.handle.cpp
+++ b/src/streaming/file.handle.cpp
@@ -1,5 +1,6 @@
 #include "definitions.hh"
 #include "file.handle.hh"
+#include "macros.hh"
 
 void*
 init_handle(const std::string& filename, const void* flags);
@@ -63,12 +64,28 @@ zarr::FileHandlePool::get_handle(const std::string& filename)
 
     auto it = cache_.find(filename);
     if (it == cache_.end()) {
-        // not in cache, open a new handle
+        // Open the new handle BEFORE mutating cache_/lru_order_. If the open
+        // fails (e.g. the parent directory was removed concurrently), the pool
+        // state is left untouched and the failure is reported to the caller as
+        // a null handle rather than thrown. FileSink::write()/flush_() check
+        // for the null handle and return false, so a recoverable I/O error no
+        // longer escapes get_handle() as an exception that would terminate the
+        // writer. (Opening first also avoids leaving an orphan lru_order_ entry
+        // when the open throws.)
+        std::shared_ptr<FileHandle> handle;
+        try {
+            handle = std::make_shared<FileHandle>(filename);
+        } catch (const std::exception& e) {
+            LOG_ERROR(
+              "Failed to open file handle for '", filename, "': ", e.what());
+            return BorrowedHandle();
+        }
+
         lru_order_.push_front(filename);
         auto [new_it, _] =
           cache_.emplace(filename,
                          CacheEntry{
-                           .handle = std::make_shared<FileHandle>(filename),
+                           .handle = std::move(handle),
                            .lru_it = lru_order_.begin(),
                            .refcount = 0,
                          });

--- a/src/streaming/file.handle.cpp
+++ b/src/streaming/file.handle.cpp
@@ -2,6 +2,9 @@
 #include "file.handle.hh"
 #include "macros.hh"
 
+#include <chrono>
+#include <thread>
+
 void*
 init_handle(const std::string& filename, const void* flags);
 
@@ -64,32 +67,64 @@ zarr::FileHandlePool::get_handle(const std::string& filename)
 
     auto it = cache_.find(filename);
     if (it == cache_.end()) {
-        // Open the new handle BEFORE mutating cache_/lru_order_. If the open
-        // fails (e.g. the parent directory was removed concurrently), the pool
-        // state is left untouched and the failure is reported to the caller as
-        // a null handle rather than thrown. FileSink::write()/flush_() check
-        // for the null handle and return false, so a recoverable I/O error no
-        // longer escapes get_handle() as an exception that would terminate the
-        // writer. (Opening first also avoids leaving an orphan lru_order_ entry
-        // when the open throws.)
+        // Not cached: open a new handle. Retry briefly on failure so a
+        // transient open error (e.g. a momentary ENOENT during a concurrent
+        // rename, or a filesystem hiccup) is recovered instead of failing the
+        // write. Open BEFORE mutating cache_/lru_order_ so a failure leaves
+        // pool state untouched; on persistent failure return a null handle,
+        // which FileSink::write()/flush_() report as a recoverable false rather
+        // than letting an exception escape and terminate the writer.
+        constexpr int max_open_attempts = 3;
+        constexpr auto open_retry_backoff = std::chrono::milliseconds(10);
         std::shared_ptr<FileHandle> handle;
-        try {
-            handle = std::make_shared<FileHandle>(filename);
-        } catch (const std::exception& e) {
-            LOG_ERROR(
-              "Failed to open file handle for '", filename, "': ", e.what());
-            return BorrowedHandle();
+        bool relocked = false;
+        for (int attempt = 1;; ++attempt) {
+            try {
+                handle = std::make_shared<FileHandle>(filename);
+                break;
+            } catch (const std::exception& e) {
+                if (attempt >= max_open_attempts) {
+                    LOG_ERROR("Failed to open file handle for '",
+                              filename,
+                              "' after ",
+                              max_open_attempts,
+                              " attempts: ",
+                              e.what());
+                    return BorrowedHandle();
+                }
+                LOG_WARNING("Open failed for '",
+                            filename,
+                            "' (attempt ",
+                            attempt,
+                            "/",
+                            max_open_attempts,
+                            "); retrying: ",
+                            e.what());
+                // Drop the pool mutex around the backoff so other handle
+                // requests are not blocked while this one waits.
+                lock.unlock();
+                std::this_thread::sleep_for(open_retry_backoff);
+                lock.lock();
+                relocked = true;
+            }
         }
 
-        lru_order_.push_front(filename);
-        auto [new_it, _] =
-          cache_.emplace(filename,
-                         CacheEntry{
-                           .handle = std::move(handle),
-                           .lru_it = lru_order_.begin(),
-                           .refcount = 0,
-                         });
-        it = new_it;
+        // If the lock was dropped to retry, another thread may have opened and
+        // cached this same file meanwhile; reuse that entry and drop ours.
+        if (relocked) {
+            it = cache_.find(filename);
+        }
+        if (it == cache_.end()) {
+            lru_order_.push_front(filename);
+            auto [new_it, _] =
+              cache_.emplace(filename,
+                             CacheEntry{
+                               .handle = std::move(handle),
+                               .lru_it = lru_order_.begin(),
+                               .refcount = 0,
+                             });
+            it = new_it;
+        }
     } else {
         // move to front of LRU
         lru_order_.splice(lru_order_.begin(), lru_order_, it->second.lru_it);

--- a/src/streaming/file.handle.cpp
+++ b/src/streaming/file.handle.cpp
@@ -109,9 +109,14 @@ zarr::FileHandlePool::get_handle(const std::string& filename)
             }
         }
 
-        // If the lock was dropped to retry, another thread may have opened and
-        // cached this same file meanwhile; reuse that entry and drop ours.
+        // If the lock was dropped to retry, cache state may have changed:
+        // another thread may have opened and cached this same file meanwhile
+        // (reuse that entry and drop ours), or filled the cache with other
+        // entries (wait for space before inserting ours).
         if (relocked) {
+            cv_.wait(lock, [&] {
+                return cache_.contains(filename) || cache_space_available_;
+            });
             it = cache_.find(filename);
         }
         if (it == cache_.end()) {

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(tests
         s3-connection-upload-multipart-object
         file-sink-write
         file-sink-close-on-destroy
+        file-sink-reopen-after-close
         shard-finalize
         s3-sink-write
         s3-sink-write-multipart

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(tests
         file-sink-write
         file-sink-close-on-destroy
         file-sink-reopen-after-close
+        file-sink-reopen-retry-recovers
         shard-finalize
         s3-sink-write
         s3-sink-write-multipart

--- a/tests/unit-tests/file-sink-reopen-after-close.cpp
+++ b/tests/unit-tests/file-sink-reopen-after-close.cpp
@@ -1,0 +1,92 @@
+// Regression test for the #226 close-on-finalize change.
+//
+// #226 made ~FileSink call pool->close() so a finalized file's fd is released
+// and the OS can reclaim its disk blocks. The side effect: a file that was
+// written, finalized, and is then written AGAIN must REOPEN via
+// FileHandlePool::get_handle() -> open(). If that reopen fails -- e.g. a
+// concurrent process removed the containing directory, which is exactly what
+// `livescreen sync` reclaim does to sealed chunk directories -- get_handle()
+// throws std::runtime_error (from init_handle()).
+//
+// In FileSink::write() that get_handle() call sits OUTSIDE the try/catch, so
+// the throw escapes write(), propagates up through the acquire-zarr worker,
+// and is reported as a fatal "Failed to append data to Zarr stream: Internal
+// error" that kills the writer thread. Before #226 the handle stayed open for
+// the store's lifetime, so this reopen never happened and the failure mode did
+// not exist.
+//
+// Desired contract: a failed (re)open is a recoverable I/O error -- write()
+// should return false, never throw out of itself. This test encodes that
+// contract, so it is EXPECTED TO FAIL on current main (write() throws) and to
+// pass once write()/get_handle handle open failures gracefully.
+
+#include "file.sink.hh"
+#include "unit.test.macros.hh"
+
+#include <filesystem>
+#include <span>
+
+namespace fs = std::filesystem;
+
+int
+main()
+{
+    int retval = 0;
+    const fs::path dir = fs::temp_directory_path() / (std::string(TEST) + "-d");
+    const fs::path file = dir / "chunk";
+
+    try {
+        auto pool = std::make_shared<zarr::FileHandlePool>();
+
+        char data[] = "reopen-after-close";
+        std::span<uint8_t> span = { reinterpret_cast<uint8_t*>(data),
+                                    sizeof(data) - 1 };
+
+        fs::create_directories(dir);
+
+        // 1. Write + finalize. ~FileSink closes the pooled handle (#226), so the
+        //    file is no longer held open by the pool.
+        {
+            auto sink =
+              std::make_unique<zarr::FileSink>(file.string(), pool);
+            CHECK(sink->write(0, span));
+            CHECK(zarr::finalize_sink(std::move(sink)));
+        }
+
+        // 2. The directory disappears underneath the writer (models sync reclaim
+        //    deleting a sealed chunk dir, or any concurrent removal).
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+
+        // 3. A further write must REOPEN the file (its handle was closed in 1).
+        //    open() now fails with ENOENT (parent gone). The writer must see a
+        //    graceful failure -- not an exception escaping write().
+        auto sink2 = std::make_unique<zarr::FileSink>(file.string(), pool);
+        bool threw = false;
+        bool ok = true;
+        try {
+            ok = sink2->write(0, span);
+        } catch (const std::exception& e) {
+            threw = true;
+            LOG_ERROR("write() threw on a failed reopen: ", e.what());
+        }
+
+        EXPECT(!threw,
+               "FileSink::write threw on a failed reopen instead of returning "
+               "false. An uncaught throw here escapes write(), propagates "
+               "through the acquire-zarr worker, and surfaces as a fatal "
+               "'Failed to append data to Zarr stream: Internal error' that "
+               "kills the writer thread (#226 close-on-finalize regression).");
+        EXPECT(!ok,
+               "FileSink::write should return false when the file cannot be "
+               "(re)opened.");
+
+    } catch (const std::exception& e) {
+        LOG_ERROR("Caught exception: ", e.what());
+        retval = 1;
+    }
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+    return retval;
+}

--- a/tests/unit-tests/file-sink-reopen-retry-recovers.cpp
+++ b/tests/unit-tests/file-sink-reopen-retry-recovers.cpp
@@ -1,0 +1,90 @@
+// Companion to file-sink-reopen-after-close: that test covers the give-up path
+// (a persistent open failure is reported as a recoverable false); this one
+// covers the RECOVERY path added by the open retry in get_handle.
+//
+// After #226 a finalized file's handle is closed, so writing it again must
+// reopen via get_handle() -> open(). get_handle retries a failed open with a
+// short backoff. Here the first open fails (the directory is gone) and another
+// thread recreates the directory during the backoff window, so a later attempt
+// succeeds: write() must return true. This proves the retry recovers a
+// transient failure rather than only failing gracefully.
+//
+// Timing: the writer's first open runs microseconds after the worker is
+// signalled and reliably fails (dir absent); the directory is recreated ~3 ms
+// later, well inside the retry window, so a subsequent attempt succeeds. Even
+// under scheduling skew the test never fails spuriously -- worst case the first
+// attempt happens to succeed and the retry simply isn't exercised.
+
+#include "file.sink.hh"
+#include "unit.test.macros.hh"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <span>
+#include <thread>
+
+namespace fs = std::filesystem;
+
+int
+main()
+{
+    int retval = 0;
+    const fs::path dir = fs::temp_directory_path() / (std::string(TEST) + "-d");
+    const fs::path file = dir / "chunk";
+
+    try {
+        auto pool = std::make_shared<zarr::FileHandlePool>();
+
+        char data[] = "reopen-retry-recovers";
+        std::span<uint8_t> span = { reinterpret_cast<uint8_t*>(data),
+                                    sizeof(data) - 1 };
+
+        fs::create_directories(dir);
+
+        // Write + finalize so the pooled handle is closed (#226); the next
+        // write must reopen.
+        {
+            auto sink =
+              std::make_unique<zarr::FileSink>(file.string(), pool);
+            CHECK(sink->write(0, span));
+            CHECK(zarr::finalize_sink(std::move(sink)));
+        }
+
+        // Remove the directory: the next open fails (ENOENT) until recreated.
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+
+        // Recreate the directory shortly after the write starts -- inside
+        // get_handle's retry/backoff window -- so a retry attempt succeeds.
+        std::atomic<bool> started{ false };
+        std::thread recreate([&] {
+            while (!started.load()) {
+                std::this_thread::yield();
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(3));
+            std::error_code mk;
+            fs::create_directories(dir, mk);
+        });
+
+        auto sink2 = std::make_unique<zarr::FileSink>(file.string(), pool);
+        started.store(true);
+        const bool ok = sink2->write(0, span); // attempt 1 fails, retry recovers
+        recreate.join();
+
+        EXPECT(ok,
+               "FileSink::write did not recover after the directory was "
+               "recreated during get_handle's retry backoff -- the open retry "
+               "is not working.");
+        EXPECT(fs::exists(file),
+               "expected the chunk file to exist after a recovered write");
+
+    } catch (const std::exception& e) {
+        LOG_ERROR("Caught exception: ", e.what());
+        retval = 1;
+    }
+
+    std::error_code ec;
+    fs::remove_all(dir, ec);
+    return retval;
+}


### PR DESCRIPTION
## Summary
=Fixes a regression from #237: a failed file reopen during
`write()` crashes the writer instead of being handled as a recoverable I/O
error. Opening early as a draft to get eyes on the failing test and confirm
the intended behavior while I build out the fix.

## Background
#237 (close sealed chunk/shard fds at finalize) changed the file-handle
lifecycle: a finalized file's handle is now closed and evicted from the
FileHandlePool, so writing that file again must reopen it via
`get_handle()` -> `open()`. Before #237 the handle stayed open for the stream's
lifetime, so a reopen never happened.

## The bug
If that reopen's `open()` fails -- e.g. the file or its parent directory was
removed concurrently by an external process -- `get_handle()` throws
`std::runtime_error` (from `init_handle()`). In `FileSink::write()` the
`get_handle()` call sits **outside** the try/catch, so the throw escapes
`write()`, propagates through the worker, and surfaces as a fatal
`Failed to append data to Zarr stream: Internal error` that terminates the
writer for that array. A recoverable I/O event becomes an unrecoverable crash.

The new `file-sink-reopen-after-close` test reproduces this deterministically
(write + finalize, remove the directory, write again) and asserts the intended
contract that `write()` returns false rather than throwing. It is expected to
FAIL on current main (CI shows the throw).