### PR TITLE
Add ZARR_MAX_THREADS environment variable override

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,6 +758,17 @@ s3_settings = aqz.S3Settings(
 settings.s3 = s3_settings
 ```
 
+### Threading
+
+The stream's thread pool size is controlled by `max_threads` (`ZarrStreamSettings.max_threads`
+in C/C++, `StreamSettings.max_threads` in Python). Leaving it at its default of `0` means
+"not explicitly set": the stream will use the `ZARR_MAX_THREADS` environment variable if it's
+set to a positive integer, or otherwise auto-detect based on hardware concurrency.
+
+- `ZARR_MAX_THREADS` is ignored if `max_threads` is explicitly set to a nonzero value.
+- An invalid `ZARR_MAX_THREADS` value (non-numeric, zero, or negative) is ignored, with a
+  warning logged, and auto-detection is used instead.
+
 ### Anaconda GLIBCXX issue
 
 If you encounter the error `GLIBCXX_3.4.30 not found` when working with the library in Python, it may be due to a

--- a/python/acquire-zarr-py.cpp
+++ b/python/acquire-zarr-py.cpp
@@ -1091,7 +1091,7 @@ class PyZarrStreamSettings
   private:
     std::string store_path_;
     mutable std::optional<PyZarrS3Settings> py_s3_settings_{ std::nullopt };
-    unsigned int max_threads_{ std::thread::hardware_concurrency() };
+    unsigned int max_threads_{ 0 };
     bool overwrite_{ false };
 
     std::vector<PyZarrArraySettings> arrays_;

--- a/python/acquire_zarr/__init__.pyi
+++ b/python/acquire_zarr/__init__.pyi
@@ -414,7 +414,9 @@ class StreamSettings:
         store_path: Path to the store. Can be a filesystem path or S3 key prefix.
             For S3, this becomes the key prefix within the specified bucket.
         s3: Optional S3 settings for cloud storage. If None, writes to local filesystem.
-        max_threads: Maximum number of threads for parallel processing.
+        max_threads: Maximum number of threads for parallel processing. Defaults to 0,
+            meaning: use the ZARR_MAX_THREADS environment variable if set, otherwise
+            auto-detect based on available hardware concurrency.
         custom_metadata: Optional JSON-formatted custom metadata to include in the dataset.
         overwrite: If True, removes any existing data at store_path before writing.
 

--- a/python/tests/test_settings.py
+++ b/python/tests/test_settings.py
@@ -277,9 +277,9 @@ def test_set_version(settings):
 
 
 def test_set_max_threads(settings):
-    assert (
-        settings.max_threads > 0
-    )  # depends on your system, but will be nonzero
+    # 0 means "not explicitly set" -- the stream will auto-detect the
+    # thread count (or honor ZARR_MAX_THREADS) when it's created.
+    assert settings.max_threads == 0
 
     settings.max_threads = 4
     assert settings.max_threads == 4

--- a/python/tests/test_stream.py
+++ b/python/tests/test_stream.py
@@ -304,6 +304,31 @@ def test_create_stream(
 
 
 @pytest.mark.parametrize(
+    ("env_value",),
+    [
+        ("2",),  # valid
+        ("not-a-number",),  # invalid, falls back to auto-detect
+    ],
+)
+def test_create_stream_honors_max_threads_env_var(
+    settings: StreamSettings,
+    store_path: Path,
+    request: pytest.FixtureRequest,
+    monkeypatch: pytest.MonkeyPatch,
+    env_value: str,
+):
+    monkeypatch.setenv("ZARR_MAX_THREADS", env_value)
+
+    assert settings.max_threads == 0  # left unset, so the env var applies
+
+    settings.store_path = str(store_path / f"{request.node.name}.zarr")
+    stream = ZarrStream(settings)
+    assert stream
+
+    stream.close()
+
+
+@pytest.mark.parametrize(
     ("compression_codec",),
     [
         (None,),

--- a/src/streaming/zarr.common.cpp
+++ b/src/streaming/zarr.common.cpp
@@ -175,6 +175,14 @@ zarr::regularize_key(const char* key)
     return regularize_key(std::string_view{ key });
 }
 
+uint32_t
+zarr::resolve_max_threads(uint32_t requested_max_threads)
+{
+    // TODO: consult the ZARR_MAX_THREADS environment variable when
+    // requested_max_threads is 0.
+    return requested_max_threads;
+}
+
 std::string
 zarr::regularize_key(const std::string_view key)
 {

--- a/src/streaming/zarr.common.cpp
+++ b/src/streaming/zarr.common.cpp
@@ -4,6 +4,8 @@
 #include <blosc.h>
 #include <zstd.h>
 
+#include <charconv>
+#include <cstdlib>
 #include <regex>
 #include <stdexcept>
 
@@ -178,9 +180,28 @@ zarr::regularize_key(const char* key)
 uint32_t
 zarr::resolve_max_threads(uint32_t requested_max_threads)
 {
-    // TODO: consult the ZARR_MAX_THREADS environment variable when
-    // requested_max_threads is 0.
-    return requested_max_threads;
+    if (requested_max_threads != 0) {
+        return requested_max_threads;
+    }
+
+    const char* env = std::getenv("ZARR_MAX_THREADS");
+    if (env == nullptr || *env == '\0') {
+        return 0;
+    }
+
+    const std::string_view value{ env };
+    uint32_t parsed = 0;
+    const auto result =
+      std::from_chars(value.data(), value.data() + value.size(), parsed);
+
+    if (result.ec != std::errc{} ||
+        result.ptr != value.data() + value.size() || parsed == 0) {
+        LOG_WARNING(
+          "Ignoring invalid ZARR_MAX_THREADS value: '", value, "'");
+        return 0;
+    }
+
+    return parsed;
 }
 
 std::string

--- a/src/streaming/zarr.common.hh
+++ b/src/streaming/zarr.common.hh
@@ -114,4 +114,16 @@ regularize_key(const char* key);
  */
 std::string
 regularize_key(std::string_view key);
+
+/**
+ * @brief Resolve the number of threads to use, applying the ZARR_MAX_THREADS
+ * environment variable when no explicit value was requested.
+ * @param requested_max_threads The value from ZarrStreamSettings.max_threads.
+ * 0 means "not explicitly set".
+ * @return @p requested_max_threads if it is non-zero; otherwise the value of
+ * ZARR_MAX_THREADS if it is set and a valid positive integer; otherwise 0
+ * (meaning: the caller should fall back to hardware_concurrency()).
+ */
+uint32_t
+resolve_max_threads(uint32_t requested_max_threads);
 } // namespace zarr

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -1428,6 +1428,7 @@ ZarrStream_s::commit_settings_(const ZarrStreamSettings* settings)
 void
 ZarrStream_s::start_thread_pool_(uint32_t max_threads)
 {
+    max_threads = zarr::resolve_max_threads(max_threads);
     max_threads =
       max_threads == 0 ? std::thread::hardware_concurrency() : max_threads;
     if (max_threads == 0) {
@@ -1807,4 +1808,10 @@ finalize_stream(ZarrStream* stream)
     }
 
     return true;
+}
+
+uint32_t
+stream_thread_count(ZarrStream* stream)
+{
+    return stream->thread_pool_->n_threads();
 }

--- a/src/streaming/zarr.stream.cpp
+++ b/src/streaming/zarr.stream.cpp
@@ -1811,7 +1811,7 @@ finalize_stream(ZarrStream* stream)
 }
 
 uint32_t
-stream_thread_count(ZarrStream* stream)
+stream_thread_count(const ZarrStream* stream)
 {
     return stream->thread_pool_->n_threads();
 }

--- a/src/streaming/zarr.stream.hh
+++ b/src/streaming/zarr.stream.hh
@@ -173,7 +173,7 @@ struct ZarrStream_s
     void finalize_frame_queue_();
 
     friend bool finalize_stream(ZarrStream* stream);
-    friend uint32_t stream_thread_count(ZarrStream* stream);
+    friend uint32_t stream_thread_count(const ZarrStream* stream);
 };
 
 bool
@@ -182,4 +182,4 @@ finalize_stream(ZarrStream* stream);
 /** @brief Get the number of threads in the stream's thread pool. Exposed for
  * testing. */
 uint32_t
-stream_thread_count(ZarrStream* stream);
+stream_thread_count(const ZarrStream* stream);

--- a/src/streaming/zarr.stream.hh
+++ b/src/streaming/zarr.stream.hh
@@ -173,7 +173,13 @@ struct ZarrStream_s
     void finalize_frame_queue_();
 
     friend bool finalize_stream(ZarrStream* stream);
+    friend uint32_t stream_thread_count(ZarrStream* stream);
 };
 
 bool
 finalize_stream(ZarrStream* stream);
+
+/** @brief Get the number of threads in the stream's thread pool. Exposed for
+ * testing. */
+uint32_t
+stream_thread_count(ZarrStream* stream);

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
         array-dimensions-shard-internal-index
         array-dimensions-courtesy-flush
         thread-pool-push-to-job-queue
+        resolve-max-threads
         construct-data-paths
         s3-connection-bucket-exists
         s3-connection-object-exists-check-false-positives

--- a/tests/unit-tests/create-stream.cpp
+++ b/tests/unit-tests/create-stream.cpp
@@ -2,9 +2,46 @@
 #include "zarr.stream.hh"
 #include "unit.test.macros.hh"
 
+#include <cstdlib>
 #include <filesystem>
+#include <optional>
+#include <string>
+#include <thread>
 
 namespace fs = std::filesystem;
+
+namespace {
+class ScopedEnvVar
+{
+  public:
+    ScopedEnvVar(const char* name, const char* value)
+      : name_{ name }
+    {
+        if (const char* existing = std::getenv(name)) {
+            previous_value_ = existing;
+        }
+
+        if (value == nullptr) {
+            unsetenv(name);
+        } else {
+            setenv(name, value, 1);
+        }
+    }
+
+    ~ScopedEnvVar()
+    {
+        if (previous_value_) {
+            setenv(name_.c_str(), previous_value_->c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+  private:
+    std::string name_;
+    std::optional<std::string> previous_value_;
+};
+} // namespace
 
 void
 configure_stream_dimensions(ZarrArraySettings* settings)
@@ -67,6 +104,34 @@ main()
         stream = ZarrStream_create(&settings);
         CHECK(nullptr != stream);
         CHECK(fs::is_directory(settings.store_path));
+
+        // ZARR_MAX_THREADS is picked up when max_threads is not explicitly
+        // set
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "2");
+
+            ZarrStreamSettings env_settings = {};
+            env_settings.store_path =
+              static_cast<const char*>(TEST "-env-max-threads.zarr");
+            env_settings.max_threads = 0;
+            CHECK(ZarrStatusCode_Success ==
+                  ZarrStreamSettings_create_arrays(&env_settings, 1));
+            configure_stream_dimensions(env_settings.arrays);
+
+            ZarrStream* env_stream = ZarrStream_create(&env_settings);
+            CHECK(nullptr != env_stream);
+
+            const uint32_t expected_threads =
+              std::thread::hardware_concurrency() <= 1 ? 1 : 2;
+            EXPECT_EQ(uint32_t, stream_thread_count(env_stream),
+                      expected_threads);
+
+            ZarrStream_destroy(env_stream);
+            ZarrStreamSettings_destroy_arrays(&env_settings);
+
+            std::error_code ec;
+            fs::remove_all(env_settings.store_path, ec);
+        }
 
         retval = 0;
     } catch (const std::exception& exception) {

--- a/tests/unit-tests/create-stream.cpp
+++ b/tests/unit-tests/create-stream.cpp
@@ -11,6 +11,33 @@
 namespace fs = std::filesystem;
 
 namespace {
+#ifdef _WIN32
+void
+set_env(const char* name, const char* value)
+{
+    _putenv_s(name, value);
+}
+
+void
+unset_env(const char* name)
+{
+    // An empty value removes the variable from the environment on Windows.
+    _putenv_s(name, "");
+}
+#else
+void
+set_env(const char* name, const char* value)
+{
+    setenv(name, value, 1);
+}
+
+void
+unset_env(const char* name)
+{
+    unsetenv(name);
+}
+#endif
+
 class ScopedEnvVar
 {
   public:
@@ -22,18 +49,18 @@ class ScopedEnvVar
         }
 
         if (value == nullptr) {
-            unsetenv(name);
+            unset_env(name);
         } else {
-            setenv(name, value, 1);
+            set_env(name, value);
         }
     }
 
     ~ScopedEnvVar()
     {
         if (previous_value_) {
-            setenv(name_.c_str(), previous_value_->c_str(), 1);
+            set_env(name_.c_str(), previous_value_->c_str());
         } else {
-            unsetenv(name_.c_str());
+            unset_env(name_.c_str());
         }
     }
 

--- a/tests/unit-tests/resolve-max-threads.cpp
+++ b/tests/unit-tests/resolve-max-threads.cpp
@@ -6,6 +6,33 @@
 #include <string>
 
 namespace {
+#ifdef _WIN32
+void
+set_env(const char* name, const char* value)
+{
+    _putenv_s(name, value);
+}
+
+void
+unset_env(const char* name)
+{
+    // An empty value removes the variable from the environment on Windows.
+    _putenv_s(name, "");
+}
+#else
+void
+set_env(const char* name, const char* value)
+{
+    setenv(name, value, 1);
+}
+
+void
+unset_env(const char* name)
+{
+    unsetenv(name);
+}
+#endif
+
 class ScopedEnvVar
 {
   public:
@@ -17,18 +44,18 @@ class ScopedEnvVar
         }
 
         if (value == nullptr) {
-            unsetenv(name);
+            unset_env(name);
         } else {
-            setenv(name, value, 1);
+            set_env(name, value);
         }
     }
 
     ~ScopedEnvVar()
     {
         if (previous_value_) {
-            setenv(name_.c_str(), previous_value_->c_str(), 1);
+            set_env(name_.c_str(), previous_value_->c_str());
         } else {
-            unsetenv(name_.c_str());
+            unset_env(name_.c_str());
         }
     }
 

--- a/tests/unit-tests/resolve-max-threads.cpp
+++ b/tests/unit-tests/resolve-max-threads.cpp
@@ -1,0 +1,113 @@
+#include "zarr.common.hh"
+#include "unit.test.macros.hh"
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+namespace {
+class ScopedEnvVar
+{
+  public:
+    ScopedEnvVar(const char* name, const char* value)
+      : name_{ name }
+    {
+        if (const char* existing = std::getenv(name)) {
+            previous_value_ = existing;
+        }
+
+        if (value == nullptr) {
+            unsetenv(name);
+        } else {
+            setenv(name, value, 1);
+        }
+    }
+
+    ~ScopedEnvVar()
+    {
+        if (previous_value_) {
+            setenv(name_.c_str(), previous_value_->c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+  private:
+    std::string name_;
+    std::optional<std::string> previous_value_;
+};
+} // namespace
+
+int
+main()
+{
+    int retval = 1;
+
+    try {
+        // explicit non-zero value wins, even when the env var is also set
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "2");
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(5), 5);
+        }
+
+        // explicit non-zero value, env var unset -> explicit value used
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", nullptr);
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(5), 5);
+        }
+
+        // env var unset, no explicit value -> defer to caller (0)
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", nullptr);
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(0), 0);
+        }
+
+        // env var set to a valid positive integer, no explicit value
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "4");
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(0), 4);
+        }
+
+        // env var set to a non-numeric value -> defer to caller (0)
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "abc");
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(0), 0);
+        }
+
+        // env var set to an empty string -> defer to caller (0)
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "");
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(0), 0);
+        }
+
+        // env var set to a value with trailing garbage -> defer to caller (0)
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "4x");
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(0), 0);
+        }
+
+        // env var set to zero -> defer to caller (0)
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "0");
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(0), 0);
+        }
+
+        // env var set to a negative value -> defer to caller (0)
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "-1");
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(0), 0);
+        }
+
+        // env var set to a value that overflows uint32_t -> defer to caller (0)
+        {
+            ScopedEnvVar env("ZARR_MAX_THREADS", "99999999999");
+            EXPECT_EQ(uint32_t, zarr::resolve_max_threads(0), 0);
+        }
+
+        retval = 0;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Exception: ", e.what());
+    }
+
+    return retval;
+}


### PR DESCRIPTION
## Use case

I'm calling acquire-zarr from ome-writers, where I don't have access to
the full settings API — I need a way to control the thread pool size
without plumbing a new parameter through. An environment variable lets
me set this from the Python side without touching the API surface
ome-writers exposes.

## Plan

- `zarr::resolve_max_threads` (src/streaming/zarr.common.hh/cpp) reads
  `ZARR_MAX_THREADS` and applies it only when `max_threads` wasn't
  explicitly set (0). Invalid values (non-numeric, <= 0, overflow) log a
  warning and fall back to auto-detection.
- Wired into `ZarrStream_s::start_thread_pool_`, so it's honored by every
  entry point (C API, C++, the JSON/YAML config loader, and Python
  bindings) since they all funnel through the same constructor.
- Still to do in this PR: `PyZarrStreamSettings.max_threads_` currently
  defaults to `hardware_concurrency()` instead of `0`, so an unset
  `max_threads` looks "explicit" by the time it reaches the C++ layer and
  the env var never takes effect for a typical Python caller. Fixing
  that default plus adding a Python-level test is the remaining work
  before this is ready for review.

Opening as draft to get CI running early; will mark ready once the
Python-side fix and tests land.

## Test plan
- [x] New unit test `resolve-max-threads` covering precedence and
      invalid-value handling
- [x] `create-stream` integration case exercising the real thread pool
      wiring end-to-end
- [x] Python-level test for the env var via the Python bindings