### PR TITLE
Bypass the OS page cache on Linux filesystem writes with O_DIRECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ZARR_DIRECT_IO` environment variable: when set, file handles are opened with `O_DIRECT` so writes bypass the OS page
+  cache. Off by default, Linux only, and only valid on filesystems that accept unaligned direct writes, such as NFS
+
 ## [0.9.0] - [2026-08-11](https://github.com/acquire-project/acquire-zarr/compare/v0.8.1...v0.9.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -769,6 +769,31 @@ set to a positive integer, or otherwise auto-detect based on hardware concurrenc
 - An invalid `ZARR_MAX_THREADS` value (non-numeric, zero, or negative) is ignored, with a
   warning logged, and auto-detection is used instead.
 
+### Direct I/O
+
+On Linux, setting the `ZARR_DIRECT_IO` environment variable opens files for writing with
+`O_DIRECT`, so written bytes bypass the OS page cache. A streaming writer never
+reads back what it wrote, so cached write data is pure overhead; on a large sustained write
+it can fill the page cache and exhaust the host's supply of free high-order (contiguous)
+memory blocks, starving unrelated drivers that need them.
+
+- Off by default.
+- **Only safe on filesystems that accept unaligned direct writes.** NFS is the tested case:
+  the client turns direct writes into WRITE RPCs without imposing a block-alignment check.
+  Sharded stores pack variable-length compressed chunks at arbitrary offsets and append a
+  small index footer, so on a block-backed filesystem (ext4, xfs, NVMe) every write fails
+  with `EINVAL`. Do not enable it there.
+- Linux only. The request is ignored, with a warning logged once, on Windows (where
+  `FILE_FLAG_NO_BUFFERING` requires sector-aligned offsets and lengths with no NFS-style
+  exemption) and on platforms without `O_DIRECT`, such as macOS.
+- S3-backed streams are unaffected.
+- Recognized true values are `1`, `true`, `on`, and `yes` (case-insensitive). Unset, empty,
+  `0`, `false`, `off`, and `no` disable it. Any other value is ignored, with a warning
+  logged, and direct I/O stays off.
+- The value is read once, at the first file open in the process, so setting it after
+  streaming has begun has no effect. When it resolves to enabled, a message is logged at
+  info level.
+
 ### Anaconda GLIBCXX issue
 
 If you encounter the error `GLIBCXX_3.4.30 not found` when working with the library in Python, it may be due to a

--- a/src/streaming/file.handle.cpp
+++ b/src/streaming/file.handle.cpp
@@ -28,10 +28,7 @@ namespace {
 bool
 direct_io_enabled()
 {
-    // Latched on first use: a getenv on every file open would be wasted work
-    // in a path that opens and closes shard files continuously. Function-local
-    // static initialization is thread-safe (C++11). The consequence is that
-    // setting ZARR_DIRECT_IO after streaming has begun has no effect.
+    // Latched: setting ZARR_DIRECT_IO mid-stream has no effect.
     static const bool enabled = [] {
         const bool value = zarr::resolve_direct_io();
         if (value) {

--- a/src/streaming/file.handle.cpp
+++ b/src/streaming/file.handle.cpp
@@ -1,6 +1,7 @@
 #include "definitions.hh"
 #include "file.handle.hh"
 #include "macros.hh"
+#include "zarr.common.hh"
 
 #include <chrono>
 #include <thread>
@@ -18,14 +19,34 @@ uint64_t
 get_max_active_handles();
 
 void*
-make_flags();
+make_flags(bool direct_io);
 
 void
 destroy_flags(const void*);
 
+namespace {
+bool
+direct_io_enabled()
+{
+    // Latched on first use: a getenv on every file open would be wasted work
+    // in a path that opens and closes shard files continuously. Function-local
+    // static initialization is thread-safe (C++11). The consequence is that
+    // setting ZARR_DIRECT_IO after streaming has begun has no effect.
+    static const bool enabled = [] {
+        const bool value = zarr::resolve_direct_io();
+        if (value) {
+            LOG_INFO("ZARR_DIRECT_IO is set; files will be opened for direct "
+                     "I/O, bypassing the OS page cache.");
+        }
+        return value;
+    }();
+    return enabled;
+}
+} // namespace
+
 zarr::FileHandle::FileHandle(const std::string& filename)
 {
-    const void* flags = make_flags();
+    const void* flags = make_flags(direct_io_enabled());
     handle_ = init_handle(filename, flags);
     destroy_flags(flags);
 }

--- a/src/streaming/posix/platform.cpp
+++ b/src/streaming/posix/platform.cpp
@@ -22,21 +22,12 @@ make_flags(bool direct_io)
     *flags = O_WRONLY | O_CREAT;
 
     if (direct_io) {
-        // A streaming writer never reads back what it wrote, so page-cache
-        // residency is pure cost; on a large sustained write it exhausts the
-        // host's high-order free lists and starves unrelated kernel-context
-        // contiguous allocations.
-        //
-        // Not the default: shards pack variable-length compressed chunks at
-        // unaligned offsets and append an index footer, and a block-backed
-        // filesystem rejects unaligned direct writes with EINVAL. NFS accepts
-        // them, since the client turns direct writes into WRITE RPCs without
-        // imposing the alignment check.
+        // Opt-in: unaligned shard writes get EINVAL on block-backed
+        // filesystems; NFS accepts them.
 #ifdef O_DIRECT
         *flags |= O_DIRECT;
 #else
-        // macOS and other POSIX platforms without O_DIRECT: warn once rather
-        // than on every open.
+        // Warn once, not on every open.
         [[maybe_unused]] static const bool warned = [] {
             LOG_WARNING("Direct I/O was requested, but O_DIRECT is not "
                         "available on this platform; writes will go through "

--- a/src/streaming/posix/platform.cpp
+++ b/src/streaming/posix/platform.cpp
@@ -16,10 +16,36 @@ get_last_error_as_string()
 }
 
 void*
-make_flags()
+make_flags(bool direct_io)
 {
     auto* flags = new int;
     *flags = O_WRONLY | O_CREAT;
+
+    if (direct_io) {
+        // A streaming writer never reads back what it wrote, so page-cache
+        // residency is pure cost; on a large sustained write it exhausts the
+        // host's high-order free lists and starves unrelated kernel-context
+        // contiguous allocations.
+        //
+        // Not the default: shards pack variable-length compressed chunks at
+        // unaligned offsets and append an index footer, and a block-backed
+        // filesystem rejects unaligned direct writes with EINVAL. NFS accepts
+        // them, since the client turns direct writes into WRITE RPCs without
+        // imposing the alignment check.
+#ifdef O_DIRECT
+        *flags |= O_DIRECT;
+#else
+        // macOS and other POSIX platforms without O_DIRECT: warn once rather
+        // than on every open.
+        [[maybe_unused]] static const bool warned = [] {
+            LOG_WARNING("Direct I/O was requested, but O_DIRECT is not "
+                        "available on this platform; writes will go through "
+                        "the OS page cache.");
+            return true;
+        }();
+#endif
+    }
+
     return flags;
 }
 

--- a/src/streaming/win32/platform.cpp
+++ b/src/streaming/win32/platform.cpp
@@ -41,11 +41,8 @@ make_flags(bool direct_io)
     *flags = FILE_FLAG_OVERLAPPED;
 
     if (direct_io) {
-        // Deliberately ignored on Windows. FILE_FLAG_NO_BUFFERING is stricter
-        // than Linux O_DIRECT: it requires sector-aligned offsets and lengths
-        // with no NFS-style exemption, whereas shards pack variable-length
-        // compressed chunks at arbitrary offsets, so every write would fail.
-        // Warn once rather than on every open.
+        // Unsupported on Windows: FILE_FLAG_NO_BUFFERING demands
+        // sector-aligned offsets, which shard writes can't satisfy.
         [[maybe_unused]] static const bool warned = [] {
             LOG_WARNING("Direct I/O was requested, but is not supported on "
                         "Windows; writes will go through the OS cache.");

--- a/src/streaming/win32/platform.cpp
+++ b/src/streaming/win32/platform.cpp
@@ -35,10 +35,24 @@ get_last_error_as_string()
 }
 
 void*
-make_flags()
+make_flags(bool direct_io)
 {
     auto* flags = new DWORD;
     *flags = FILE_FLAG_OVERLAPPED;
+
+    if (direct_io) {
+        // Deliberately ignored on Windows. FILE_FLAG_NO_BUFFERING is stricter
+        // than Linux O_DIRECT: it requires sector-aligned offsets and lengths
+        // with no NFS-style exemption, whereas shards pack variable-length
+        // compressed chunks at arbitrary offsets, so every write would fail.
+        // Warn once rather than on every open.
+        [[maybe_unused]] static const bool warned = [] {
+            LOG_WARNING("Direct I/O was requested, but is not supported on "
+                        "Windows; writes will go through the OS cache.");
+            return true;
+        }();
+    }
+
     return flags;
 }
 

--- a/src/streaming/zarr.common.cpp
+++ b/src/streaming/zarr.common.cpp
@@ -4,6 +4,8 @@
 #include <blosc.h>
 #include <zstd.h>
 
+#include <algorithm>
+#include <cctype>
 #include <charconv>
 #include <cstdlib>
 #include <regex>
@@ -202,6 +204,33 @@ zarr::resolve_max_threads(uint32_t requested_max_threads)
     }
 
     return parsed;
+}
+
+bool
+zarr::resolve_direct_io()
+{
+    const char* env = std::getenv("ZARR_DIRECT_IO");
+    if (env == nullptr || *env == '\0') {
+        return false;
+    }
+
+    std::string value{ env };
+    std::transform(value.begin(), value.end(), value.begin(), [](char c) {
+        return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    });
+
+    if (value == "1" || value == "true" || value == "on" || value == "yes") {
+        return true;
+    }
+
+    if (value == "0" || value == "false" || value == "off" || value == "no") {
+        return false;
+    }
+
+    // Fail closed: wrongly enabling direct I/O fails every write with EINVAL
+    // on a block-backed filesystem.
+    LOG_WARNING("Ignoring invalid ZARR_DIRECT_IO value: '", env, "'");
+    return false;
 }
 
 std::string

--- a/src/streaming/zarr.common.cpp
+++ b/src/streaming/zarr.common.cpp
@@ -227,8 +227,7 @@ zarr::resolve_direct_io()
         return false;
     }
 
-    // Fail closed: wrongly enabling direct I/O fails every write with EINVAL
-    // on a block-backed filesystem.
+    // Fail closed: enabling this by mistake fails every write with EINVAL.
     LOG_WARNING("Ignoring invalid ZARR_DIRECT_IO value: '", env, "'");
     return false;
 }

--- a/src/streaming/zarr.common.hh
+++ b/src/streaming/zarr.common.hh
@@ -126,4 +126,15 @@ regularize_key(std::string_view key);
  */
 uint32_t
 resolve_max_threads(uint32_t requested_max_threads);
+
+/**
+ * @brief Whether to bypass the OS page cache when opening files for writing,
+ * from the ZARR_DIRECT_IO environment variable.
+ * @return true if ZARR_DIRECT_IO is set to a recognized true value ("1",
+ * "true", "on", "yes", case-insensitive); false if it is unset, empty, or set
+ * to a recognized false value ("0", "false", "off", "no"). An unrecognized
+ * value logs a warning and returns false.
+ */
+bool
+resolve_direct_io();
 } // namespace zarr

--- a/src/streaming/zarr.common.hh
+++ b/src/streaming/zarr.common.hh
@@ -128,12 +128,9 @@ uint32_t
 resolve_max_threads(uint32_t requested_max_threads);
 
 /**
- * @brief Whether to bypass the OS page cache when opening files for writing,
- * from the ZARR_DIRECT_IO environment variable.
- * @return true if ZARR_DIRECT_IO is set to a recognized true value ("1",
- * "true", "on", "yes", case-insensitive); false if it is unset, empty, or set
- * to a recognized false value ("0", "false", "off", "no"). An unrecognized
- * value logs a warning and returns false.
+ * @brief Whether ZARR_DIRECT_IO asks writes to bypass the OS page cache.
+ * Honored on Linux only; ignored on Windows and macOS.
+ * @return true for "1", "true", "on", "yes" (case-insensitive), else false.
  */
 bool
 resolve_direct_io();

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
         array-dimensions-courtesy-flush
         thread-pool-push-to-job-queue
         resolve-max-threads
+        resolve-direct-io
         construct-data-paths
         s3-connection-bucket-exists
         s3-connection-object-exists-check-false-positives

--- a/tests/unit-tests/resolve-direct-io.cpp
+++ b/tests/unit-tests/resolve-direct-io.cpp
@@ -16,7 +16,7 @@ set_env(const char* name, const char* value)
 void
 unset_env(const char* name)
 {
-    // An empty value removes the variable from the environment on Windows.
+    // An empty value removes the variable on Windows.
     _putenv_s(name, "");
 }
 #else

--- a/tests/unit-tests/resolve-direct-io.cpp
+++ b/tests/unit-tests/resolve-direct-io.cpp
@@ -1,0 +1,118 @@
+#include "zarr.common.hh"
+#include "unit.test.macros.hh"
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+namespace {
+#ifdef _WIN32
+void
+set_env(const char* name, const char* value)
+{
+    _putenv_s(name, value);
+}
+
+void
+unset_env(const char* name)
+{
+    // An empty value removes the variable from the environment on Windows.
+    _putenv_s(name, "");
+}
+#else
+void
+set_env(const char* name, const char* value)
+{
+    setenv(name, value, 1);
+}
+
+void
+unset_env(const char* name)
+{
+    unsetenv(name);
+}
+#endif
+
+class ScopedEnvVar
+{
+  public:
+    ScopedEnvVar(const char* name, const char* value)
+      : name_{ name }
+    {
+        if (const char* existing = std::getenv(name)) {
+            previous_value_ = existing;
+        }
+
+        if (value == nullptr) {
+            unset_env(name);
+        } else {
+            set_env(name, value);
+        }
+    }
+
+    ~ScopedEnvVar()
+    {
+        if (previous_value_) {
+            set_env(name_.c_str(), previous_value_->c_str());
+        } else {
+            unset_env(name_.c_str());
+        }
+    }
+
+  private:
+    std::string name_;
+    std::optional<std::string> previous_value_;
+};
+
+void
+expect_direct_io(const char* value, bool expected)
+{
+    ScopedEnvVar env("ZARR_DIRECT_IO", value);
+    EXPECT_EQ(bool, zarr::resolve_direct_io(), expected);
+}
+} // namespace
+
+int
+main()
+{
+    int retval = 1;
+
+    try {
+        // unset -> disabled
+        expect_direct_io(nullptr, false);
+
+        // empty -> disabled
+        expect_direct_io("", false);
+
+        // recognized true spellings
+        expect_direct_io("1", true);
+        expect_direct_io("true", true);
+        expect_direct_io("on", true);
+        expect_direct_io("yes", true);
+
+        // recognized false spellings
+        expect_direct_io("0", false);
+        expect_direct_io("false", false);
+        expect_direct_io("off", false);
+        expect_direct_io("no", false);
+
+        // matching is case-insensitive
+        expect_direct_io("TRUE", true);
+        expect_direct_io("On", true);
+        expect_direct_io("YeS", true);
+        expect_direct_io("FALSE", false);
+        expect_direct_io("Off", false);
+
+        // unrecognized values fail closed
+        expect_direct_io("maybe", false);
+        expect_direct_io("2", false);
+        expect_direct_io("1x", false);
+        expect_direct_io(" 1", false);
+
+        retval = 0;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Exception: ", e.what());
+    }
+
+    return retval;
+}


### PR DESCRIPTION
## Read this first: the caveat

`O_DIRECT` normally requires file offsets, buffer addresses, and lengths to be block-aligned. **Sharded Zarr writes satisfy none of these** — a shard packs variable-length compressed chunks back to back and appends a 16-byte-per-chunk index footer, so offsets and lengths are arbitrary.

On a block-backed filesystem (ext4, xfs, NVMe) those writes fail with `EINVAL`. On NFS the client turns direct writes into WRITE RPCs without imposing the alignment check, so the packed layout is accepted.

So this is **off by default, Linux only, and opt-in by an environment variable that does not exist in any public API**. Enabling it on the wrong filesystem kills the acquisition at the first shard flush. That is deliberate — see "Why such a minimal interface" below.

## Problem

acquire-zarr streams to disk and never reads back what it wrote. Every byte written also lands in the page cache for no benefit: nothing will ever hit that cache.

On a short write that is harmless. On a sustained multi-terabyte write it is actively harmful, and not for the reason you would guess:

- The kernel satisfies some allocations from **physically contiguous** blocks of high order (order-9 = 2 MB). Drivers doing DMA need these.
- A page cache that grows to fill RAM fragments the free lists, so high-order blocks stop being available even while plenty of memory is nominally free.
- `MemAvailable` does not reveal this. It read ~330 GB throughout the failures below. The quantity that matters is the count of free blocks of order >= 9 in `/proc/buddyinfo`.

Measured writing 500 GB to a VAST NFS mount on a 377 GB host:

| | page-cache retention | free >= 2 MB blocks, floor | throughput |
|---|---|---|---|
| buffered (today) | 78.8% * | **0.25 GB** (from 390 GB) | 2205 MB/s |
| `O_DIRECT` | **0.0%** | 389.997 GB (unchanged) | **6298 MB/s** |

\* capped by physical RAM, not by writeback behavior.

Downstream consequence in our application: an NI DAQmx driver's order-9 `kmalloc` began failing with `-52000` after 30-100 hours of continuous acquisition, killing multi-day microscope runs. A 48-hour production run with direct I/O showed page cache flat at ~5 MB/h (fully accounted for by log files, not the writer), free >= 2 MB holding at 326 GB of 361 GB, and zero compaction failures, with ~29 TB through the writer.

**Direct I/O is 2.9x faster here, not slower.** At this scale the buffered path is throttled by its own cache saturation (dirty throttling plus reclaim), while direct writes go to the wire at roughly 50% of 100 GbE line rate. Below a few GB the two are within noise — small-scale parity is not a regression.

## Change

`zarr::resolve_direct_io()` reads `ZARR_DIRECT_IO`; `FileHandle` latches it in a function-local static at the first file open and passes it to `make_flags()`, which adds `O_DIRECT` on POSIX. Four source files plus a unit test.

- True: `1`, `true`, `on`, `yes` (case-insensitive). False: unset, empty, `0`, `false`, `off`, `no`. Anything else logs a warning and fails closed — the failure mode of wrongly enabling this is `EINVAL` on every write.
- Latched once per process, so setting the variable after streaming has begun has no effect. One `LOG_INFO` when it resolves enabled, so a deployment can confirm the mode is actually active.
- Ignored with a one-shot warning on Windows (`FILE_FLAG_NO_BUFFERING` requires sector alignment with no NFS-style exemption, so every write would fail) and on platforms without `O_DIRECT`, such as macOS.
- S3-backed streams are unaffected: `make_flags()` is only reached by the filesystem sink.
- No public API surface. No change to `acquire.zarr.h`, the Python bindings, the `.pyi` stub, or the YAML/JSON settings schema.

## Why such a minimal interface

The natural design is a `ZarrStreamSettings.direct_io` field. Rejected on purpose:

- Whether direct I/O is legal is a property of **where the process runs**, not of the dataset. The same code and settings are correct on NFS and wrong on ext4. An environment variable is set by whoever deploys the process, who knows the mount; a settings field invites a caller to set it per-dataset without knowing.
- It keeps callers out of the alignment question entirely, and there is nothing to version or deprecate if the approach changes.
- Precedent: `ZARR_MAX_THREADS` (#239) established the pattern, resolver style, unit-test shape, and docs location. This mirrors it so review is about the mechanism, not the convention.
- Obscurity is a feature at this stage. You have to know what you are doing to find and set it, which is the right bar for a flag that fails hard on the wrong filesystem.

Accepted cost: process-global, cannot vary per stream, and cannot be introspected by a caller. The `LOG_INFO` mitigates the last one.

## Testing

- `tests/unit-tests/resolve-direct-io.cpp` covers unset, empty, every true/false spelling, mixed case, and unrecognized values, reusing the `ScopedEnvVar` helper from `resolve-max-threads.cpp`.
- Full non-S3 suite passes.
- End-to-end on ext4: `ZARR_DIRECT_IO=1` fails loudly at the first shard write with "Invalid argument" rather than corrupting anything, which is the documented boundary; the info line and the invalid-value warning both fire as intended.
- **No default-on integration test.** CI runners use block-backed filesystems where such a test fails `EINVAL` by design. An opt-in test pointed at an NFS mount would be welcome.
- **Verified on NFS.** I write to a VAST NFS export, and checked the packed layout there directly across five alignment cases — aligned writes, unaligned lengths, unaligned offsets, a 16-byte footer at an unaligned offset, and a misaligned user buffer. All five succeed, and 473 packed regions plus the footer read back byte-exact. The same mount is carrying the production acquisition described above with `ZARR_DIRECT_IO=1`, stores readable throughout.

## Suggested follow-ups

Deliberately out of scope here; happy to fold either into this PR if you would rather they land together.

1. **Capability probe as a guard.** At stream open, create a temp file in the store root with `O_DIRECT` and attempt exactly the write shape we produce (odd length, unaligned buffer, 16-byte footer at an arbitrary offset), then unlink. Verified locally that this discriminates correctly — ext4 accepts the *open* and rejects both writes, so an open-only probe would be useless. Used as a guard rather than an enabler, it turns "the acquisition dies at the first shard flush" into a startup warning and a buffered fallback.

   Preferred over detecting the filesystem type. `statfs` `f_type == NFS_SUPER_MAGIC` is cheaper and side-effect-free, but it answers the wrong question: it needs a filesystem allowlist, and would wrongly reject Lustre/GPFS/FUSE-fronted NFS while wrongly accepting an NFS client that does enforce alignment. The property we care about is "accepts unaligned direct writes," which the probe tests directly.

2. **Plumb a real parameter through.** `ZarrStreamSettings.direct_io` plus Python binding, `.pyi`, and settings schema, with the environment variable as the fallback when the field is unset — exactly the `max_threads` precedence rule from #239. Worth doing once the semantics have survived contact with more than one filesystem; doing it now would freeze a public field around behavior tested on a single mount type. Pairs naturally with (1), which is what makes a per-stream field safe to expose: a caller who sets it without knowing the target gets a warning instead of a dead acquisition.

## Open questions

1. **Should there be a third `auto` value?** Today the flag is explicitly on or off, and off unless you know the variable exists. An alternative is to accept `ZARR_DIRECT_IO=auto`, which enables direct I/O only if the target is confirmed to accept unaligned direct writes (via the probe in follow-up 1, or `statfs` `f_type == NFS_SUPER_MAGIC`), logs which way it resolved, and leaves unset still meaning buffered. That gives a mixed fleet one knob without changing anyone's behavior silently.

   I would not want detection to fire *without* being asked for, and the reason is in the write path rather than in the alignment rules: `Shard::write_chunk` issues one `sink_->write` per compressed chunk (`shard.cpp:91`), plus one for the index table (`shard.cpp:164`), so writes are chunk-sized, not shard-sized. Buffered, the page cache coalesces those into large writeback batches; direct, each becomes its own synchronous WRITE RPC. The 2.9x win above was a sustained 500 GB write over 100 GbE, where that trade pays. With small chunks on a higher-latency mount it could go the other way, and nothing in the codebase sizes writes to compensate. Auto-enabling on detection would mean a user's throughput changes on upgrade with no signal and no documented way back — a worse failure mode than the loud `EINVAL` you get today from asking for something the filesystem will not do.

   Also worth noting that `statfs` reporting NFS is weaker evidence than it appears: it says nothing about the server, mount options, NFS version, or a FUSE-fronted client presenting as NFS. So `auto` should be backed by the probe, not by the filesystem type.

   Three ways to go, in my order of preference: explicit only (this PR as it stands); explicit plus `auto` opt-in; or auto-detect by default. Happy to implement the second here if you want it in the same change — it is a third case in the existing resolver, not a new mechanism.

2. **Windows.** This PR ignores the request and warns once. The alternatives were to wire up `FILE_FLAG_NO_BUFFERING` untested (it requires sector-aligned offsets and lengths with no NFS-style exemption, so sharded writes would fail), or to scope the flag to POSIX and error out on Windows. Ignore-and-warn seemed least surprising, but say if you would rather it be loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

