### PR TITLE
Run MinIO from its container image in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,11 @@ jobs:
       MINIO_BUCKET: acquire-test
       MINIO_ACCESS_KEY: acquire
       MINIO_SECRET_KEY: 12345678
+      # dl.min.io now answers 410 Gone: MinIO archived the community server
+      # and mc and stopped serving their binaries. The container images are
+      # still published, so pull them from there instead.
+      MINIO_IMAGE: minio/minio:RELEASE.2025-09-07T16-13-09Z
+      MC_IMAGE: minio/mc:RELEASE.2025-08-13T08-35-41Z
 
     steps:
       - uses: actions/checkout@v4
@@ -161,25 +166,42 @@ jobs:
         with:
           cmake-version: "3.31.x"
 
-      - name: Install minio and mcli
+      - name: Start minio
         run: |
-          apt update && apt install -y tmux wget
-          wget https://dl.min.io/server/minio/release/linux-amd64/minio -O /usr/local/bin/minio
-          wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mcli
-          chmod +x /usr/local/bin/minio
-          chmod +x /usr/local/bin/mcli
+          # nothing here uses the web console, so neither its port nor
+          # --console-address is worth carrying
+          docker run -d --name minio -p 9000:9000 \
+            -e "MINIO_ROOT_USER=$MINIO_ROOT_USER" \
+            -e "MINIO_ROOT_PASSWORD=$MINIO_ROOT_PASSWORD" \
+            "$MINIO_IMAGE" server /data
+          for _ in $(seq 60); do
+            if curl -fsS "$MINIO_URL/minio/health/live" >/dev/null; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ -z "$ready" ]; then
+            docker logs minio >&2
+            echo "minio did not become ready" >&2
+            exit 1
+          fi
 
-      - name: Start minio in tmux
+      - name: Create a service account and a bucket
         run: |
-          tmux new -d -s minio
-          tmux send-keys -t minio "MINIO_ROOT_USER=$MINIO_ROOT_USER MINIO_ROOT_PASSWORD=$MINIO_ROOT_PASSWORD minio server /tmp/minio --console-address :9001" Enter
-          sleep 5
-          mcli alias set $MINIO_ALIAS $MINIO_URL $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
-          mcli admin user svcacct add --access-key $MINIO_ACCESS_KEY --secret-key $MINIO_SECRET_KEY $MINIO_ALIAS $MINIO_ROOT_USER
-
-      - name: Create a bucket
-        run: |
-          mcli mb $MINIO_ALIAS/$MINIO_BUCKET
+          # mc keeps its aliases in a config file, which a --rm container
+          # throws away, so pass the target through MC_HOST_<alias> instead
+          mc_host="http://$MINIO_ROOT_USER:$MINIO_ROOT_PASSWORD@${MINIO_URL#http://}"
+          mcli() {
+            docker run --rm --network host \
+              -e "MC_HOST_$MINIO_ALIAS=$mc_host" \
+              "$MC_IMAGE" "$@"
+          }
+          mcli admin user svcacct add \
+            --access-key "$MINIO_ACCESS_KEY" \
+            --secret-key "$MINIO_SECRET_KEY" \
+            "$MINIO_ALIAS" "$MINIO_ROOT_USER"
+          mcli mb "$MINIO_ALIAS/$MINIO_BUCKET"
 
       - name: Install vcpkg
         run: |


### PR DESCRIPTION
`dl.min.io` now answers `410 Gone` for both the community server and `mc`
binaries, so the **Test S3** job dies at the install step:

```
410 Gone

The open-source MinIO Server, MinIO Client (mc) and MinIO KES projects are
archived and no longer maintained. ... These files are no longer served from
this site. This applies to all community releases and to all hotfix builds
for them.
```

The container images are still published, so this pulls MinIO from there
instead:

- `docker run` of `minio/minio:RELEASE.2025-09-07T16-13-09Z` replaces the
  `wget` into `/usr/local/bin`, and `mc` runs from
  `minio/mc:RELEASE.2025-08-13T08-35-41Z`. Both are pinned rather than
  `:latest`, since the projects are archived and untagged movement is not
  something we want to inherit.
- `mc` keeps its aliases in a config file that a `--rm` container discards, so
  the target goes through `MC_HOST_<alias>` rather than `mc alias set`. The
  service account and bucket steps are otherwise unchanged.
- Readiness polls `/minio/health/live` instead of `sleep 5`, and the tmux
  session, the `apt install tmux wget` step, and the console port (nothing
  here uses the web console) are gone.

`MINIO_*` env names and the credentials handed to the tests are unchanged, so
the build/test steps below are untouched.

**Verification:** static only, locally — the workflow YAML parses, both `run`
blocks pass `bash -n`, and both image tags still resolve to a linux/amd64
manifest in the registry. I could not exercise the container flow on the
machine I wrote this on (Docker Desktop in Windows-containers mode), so this
PR's own Test S3 run is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)